### PR TITLE
Add codeaws-test-runner

### DIFF
--- a/packages/codeaws-test-runner/bin/cli.ts
+++ b/packages/codeaws-test-runner/bin/cli.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+// CODE.AWS Test Runner and Test Adapters
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+/* eslint-disable header/header */
+
+import yargs from 'yargs/yargs'
+import { hideBin } from 'yargs/helpers'
+
+import run from '../src/run'
+import discover from '../src/protocol'
+import { loadAdapter } from '../src/adapter'
+
+const argv = yargs(hideBin(process.argv))
+  .usage('Usage: $0 <adapter> [args]')
+  .version()
+  .alias('version', 'v')
+  .help()
+  .alias('help', 'h')
+  .demandCommand(1, 1)
+  .strict(true)
+  .parseSync()
+
+const [adapterPath] = argv._
+
+const discoveryResult = discover(process.env)
+
+loadAdapter(String(adapterPath), process).then((adapter) => {
+  return run(adapter, discoveryResult, process)
+})

--- a/packages/codeaws-test-runner/src/adapter.ts
+++ b/packages/codeaws-test-runner/src/adapter.ts
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import log from './log'
+import path from 'path'
+
+export interface TestCase {
+  testName: string
+  suiteName?: string
+  filepath?: string
+}
+
+export interface AdapterInput {
+  testsToRun?: TestCase[]
+}
+
+export interface AdapterOutput {
+  exitCode?: number | null
+}
+
+export interface Adapter {
+  executeTests(options: AdapterInput): Promise<AdapterOutput> | AdapterOutput
+}
+
+type Process = Pick<typeof process, 'cwd'>
+
+export async function loadAdapter(adapterModule: string, processObject: Process): Promise<Adapter> {
+  try {
+    const adapterImportPath = adapterModule.startsWith('.')
+      ? path.join(processObject.cwd(), adapterModule)
+      : adapterModule
+    const adapter = await import(adapterImportPath)
+    log.stderr('Loaded adapter from', adapterModule)
+    return adapter
+  } catch (e) {
+    log.stderr('Failed to load adapter from', adapterModule)
+    throw e
+  }
+}

--- a/packages/codeaws-test-runner/src/index.ts
+++ b/packages/codeaws-test-runner/src/index.ts
@@ -1,0 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { AdapterInput, AdapterOutput, TestCase } from './adapter'
+
+export { AdapterInput, AdapterOutput, TestCase }

--- a/packages/codeaws-test-runner/src/log.ts
+++ b/packages/codeaws-test-runner/src/log.ts
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-console */
+
+type LogHandler = (...args: any[]) => void
+
+interface Logger {
+  stderr: LogHandler
+}
+
+function prefix(fn: LogHandler, prefixString: string): LogHandler {
+  return (...args: any[]): void => {
+    fn(prefixString, ...args)
+  }
+}
+
+export function makeLogger(methods: Logger, prefixString: string): Logger {
+  return {
+    stderr: prefix(methods.stderr, prefixString),
+  }
+}
+
+const LOG_PREFIX = '[codeaws-test-runner]:'
+
+export default makeLogger(
+  {
+    stderr: console.error,
+  },
+  LOG_PREFIX,
+)

--- a/packages/codeaws-test-runner/src/protocol.ts
+++ b/packages/codeaws-test-runner/src/protocol.ts
@@ -1,0 +1,40 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import log from './log'
+
+interface TestCase {
+  testName: string
+  suiteName?: string
+  filepath?: string
+}
+
+export interface DiscoveryResult {
+  testsToRun: TestCase[]
+}
+
+type Environment = { [key: string]: string | undefined }
+
+function discoverTestNamesToRun(input: string | undefined): TestCase[] {
+  return input?.split('|').map((testName) => ({ testName })) ?? []
+}
+
+function mapEnvToResult<T>(
+  env: Environment,
+  key: string,
+  mapper: (input: string | undefined) => T,
+): T {
+  const value = env[key]
+  if (typeof value !== 'undefined') {
+    log.stderr(`Discovered ${key} in environment, parsing value`)
+  }
+  return mapper(value)
+}
+
+function discover(env: Environment): DiscoveryResult {
+  return {
+    testsToRun: mapEnvToResult(env, 'CAWS_TEST_NAMES_TO_RUN', discoverTestNamesToRun),
+  }
+}
+
+export default discover

--- a/packages/codeaws-test-runner/src/run.ts
+++ b/packages/codeaws-test-runner/src/run.ts
@@ -1,0 +1,29 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import log from './log'
+import { Adapter, AdapterInput } from './adapter'
+import { DiscoveryResult } from './protocol'
+
+type Process = Pick<typeof process, 'exit'>
+
+function mapDiscoveryResultToAdapterInput(discoveryResult: DiscoveryResult): AdapterInput {
+  return {
+    testsToRun: discoveryResult.testsToRun,
+  }
+}
+
+async function run(adapter: Adapter, discoveryResult: DiscoveryResult, processObject: Process) {
+  try {
+    const adapterInput = mapDiscoveryResultToAdapterInput(discoveryResult)
+    log.stderr('Calling executeTests on adapter...')
+    const { exitCode } = await adapter.executeTests(adapterInput)
+    log.stderr('Finished executing tests.')
+    processObject.exit(exitCode ?? 1)
+  } catch (e) {
+    log.stderr('Failed to run tests.', e)
+    processObject.exit(1)
+  }
+}
+
+export default run

--- a/packages/codeaws-test-runner/tests/adapter.test.ts
+++ b/packages/codeaws-test-runner/tests/adapter.test.ts
@@ -1,0 +1,60 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'path'
+
+jest.mock('../src/log')
+
+describe('Loading an adapter', () => {
+  it('loads the correct adapter from an absolute path', async () => {
+    const fullAdapterPath = path.join('my', 'full', 'path', 'adapter.js')
+    const mockAdapter = { executeTests: () => ({ exitCode: 123 }) }
+    jest.doMock(fullAdapterPath, () => mockAdapter, { virtual: true })
+    const { loadAdapter } = await import('../src/adapter')
+
+    const adapter = await loadAdapter(fullAdapterPath, process)
+
+    expect(adapter.executeTests({ testsToRun: [] })).toEqual({ exitCode: 123 })
+  })
+
+  it('loads the correct adapter from a relative path', async () => {
+    const directory = path.join('my', 'cool', 'dir')
+    const adapterPath = './adapter.js'
+    const fullAdapterPath = path.join(directory, adapterPath)
+    const mockAdapter = { executeTests: () => ({ exitCode: 123 }) }
+    jest.doMock(fullAdapterPath, () => mockAdapter, { virtual: true })
+    const { loadAdapter } = await import('../src/adapter')
+
+    const adapter = await loadAdapter(adapterPath, { cwd: () => directory })
+
+    expect(adapter.executeTests({ testsToRun: [] })).toEqual({ exitCode: 123 })
+  })
+
+  it('loads the adapter from the default export when one is provided', async () => {
+    const fullAdapterPath = path.join('my', 'full', 'path', 'adapter.js')
+    const mockAdapter = {
+      __esModule: true,
+      default: { executeTests: () => ({ exitCode: 123 }) },
+      executeTests: () => ({ exitCode: 456 }),
+    }
+    jest.doMock(fullAdapterPath, () => mockAdapter, { virtual: true })
+    const { loadAdapter } = await import('../src/adapter')
+
+    const adapter = await loadAdapter(fullAdapterPath, process)
+
+    expect(adapter.executeTests({ testsToRun: [] })).toEqual({ exitCode: 123 })
+  })
+
+  it.each(['blah', './blah.js'])(
+    'throws an error when loading a non-existent adatper from %s',
+    async (adapterPath: string) => {
+      const { loadAdapter } = await import('../src/adapter')
+      expect.assertions(1)
+      try {
+        await loadAdapter(adapterPath, process)
+      } catch (e: any) {
+        expect(e.code).toBe('MODULE_NOT_FOUND')
+      }
+    },
+  )
+})

--- a/packages/codeaws-test-runner/tests/discover.test.ts
+++ b/packages/codeaws-test-runner/tests/discover.test.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import discover from '../src/protocol'
+
+jest.mock('../src/log')
+
+describe('Discovery function', () => {
+  describe('when parsing CAWS_TEST_NAMES_TO_RUN', () => {
+    it('discovers a list of test names', () => {
+      const result = discover({ CAWS_TEST_NAMES_TO_RUN: 'test1|test4|test9' })
+      expect(result.testsToRun).toEqual([
+        { testName: 'test1' },
+        { testName: 'test4' },
+        { testName: 'test9' },
+      ])
+    })
+
+    it('discovers an empty list when value is not present', () => {
+      const result = discover({})
+      expect(result.testsToRun).toEqual([])
+    })
+  })
+})

--- a/packages/codeaws-test-runner/tests/log.test.ts
+++ b/packages/codeaws-test-runner/tests/log.test.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { makeLogger } from '../src/log'
+
+describe('Logger', () => {
+  it('adds the log prefix to the stderr method', () => {
+    const stderr = jest.fn()
+    const logger = makeLogger({ stderr }, 'my-cool-prefix:')
+    logger.stderr('what', 'is', 'up')
+    expect(stderr).toHaveBeenCalledWith('my-cool-prefix:', 'what', 'is', 'up')
+  })
+})

--- a/packages/codeaws-test-runner/tests/run.test.ts
+++ b/packages/codeaws-test-runner/tests/run.test.ts
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import run from '../src/run'
+
+jest.mock('../src/log')
+
+function getProcessSpy() {
+  return {
+    exit: jest.fn<never, [number]>(),
+  }
+}
+
+describe('Run function', () => {
+  it('exits with the exit code returned by the adapter', async () => {
+    const mockAdapter = {
+      executeTests() {
+        return { exitCode: 123 }
+      },
+    }
+    const processSpy = getProcessSpy()
+    await run(mockAdapter, { testsToRun: [] }, processSpy)
+    expect(processSpy.exit).toHaveBeenCalledWith(123)
+  })
+
+  it('exits with a non-zero status code if the adapter throws an error', async () => {
+    const mockAdapter = {
+      executeTests() {
+        throw new Error('Random failure')
+      },
+    }
+    const processSpy = getProcessSpy()
+    await run(mockAdapter, { testsToRun: [] }, processSpy)
+    expect(processSpy.exit).toHaveBeenCalledWith(1)
+  })
+
+  it('exits with a non-zero status code if the adapter does not return an status code', async () => {
+    const mockAdapter = {
+      executeTests() {
+        return { exitCode: null }
+      },
+    }
+    const processSpy = getProcessSpy()
+    await run(mockAdapter, { testsToRun: [] }, processSpy)
+    expect(processSpy.exit).toHaveBeenCalledWith(1)
+  })
+})


### PR DESCRIPTION
## Description

Add base test runner package that interprets the discovery protocol and calls the given adapter. See https://github.com/aws/codeaws-test-runner/blob/main/protocol/rfcs/0001/0001.md for discovery protocol documentation.

NB: this is a retroactive PR to get feedback now that we're moving out of the prototyping phase and preparing to recommend this package for external consumption.

## Testing

Ran the CLI locally with various adapters.

## Checklist

I have:
* [x] Added new automated tests for any new functionality

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
