### PR TITLE
Add jest adapter

### DIFF
--- a/packages/codeaws-test-adapter-jest/src/buildBaseTestCommand.ts
+++ b/packages/codeaws-test-adapter-jest/src/buildBaseTestCommand.ts
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import path from 'path'
+import { access, readFile } from 'fs/promises'
+import log from './log'
+
+/**
+ * Start by determining what executable to use, then what args to pass to the executable.
+ *
+ * Executable:
+ * - If the user has defined a package.json that we detect as executing jest in some way:
+ *   - Assume that we'll run tests via their package manager
+ *   - If a yarn.lock file is present, use `yarn` as our executable. Otherwise use `npm`
+ * - Otherwise, use ./node_modules/.bin/jest as the executable if present
+ * - Otherwise, use global jest
+ *
+ * Args:
+ * - If we are invoking via package manager, use the script name as the first arg
+ * - Add any jest-specific args required to run the tests according to what's passed by the runner
+ */
+export default async function buildBaseTestCommand(): Promise<[string, string[]]> {
+  try {
+    const packageJsonContents = await loadPackageJson()
+    const packageJson = parsePackageJson(packageJsonContents)
+    const testScriptName = pickTestScript(packageJson)
+    return await buildPackageManagerTestCommand(testScriptName)
+  } catch (e: any) {
+    log.stderr(e.message)
+    const jestExecutablePath = path.join('.', 'node_modules', '.bin', 'jest')
+    const executable = (await exists(jestExecutablePath)) ? jestExecutablePath : 'jest'
+    return [executable, []]
+  }
+}
+
+async function loadPackageJson(): Promise<string> {
+  try {
+    return await readFile(path.resolve('.', 'package.json'), 'utf-8')
+  } catch (e) {
+    throw new Error('Unable to load package.json')
+  }
+}
+
+interface PackageJson {
+  scripts?: { [key: string]: any }
+}
+
+function parsePackageJson(contents: string): PackageJson {
+  try {
+    return JSON.parse(contents)
+  } catch (e) {
+    throw new Error('Unable to parse package.json contents')
+  }
+}
+
+function pickTestScript(packageJson: PackageJson): string {
+  const { scripts = {} } = packageJson
+  const testScripts = Object.entries(scripts).filter(([, script]: [string, any]) => {
+    const tokens = new Set(String(script).split(' '))
+    return tokens.has('jest') || tokens.has(path.join('node_modules', '.bin', 'jest'))
+  })
+  const scriptNames = testScripts.map(([scriptName]) => scriptName).join(', ')
+  log.stderr(`Found ${testScripts.length} possible test script(s) in package.json: ${scriptNames}`)
+  const testScript =
+    testScripts.find(([scriptName]: [string, any]) => scriptName === 'test') || testScripts[0]
+  if (!testScript) {
+    throw new Error('Unable to identify any test scripts in package.json')
+  }
+  const [scriptName] = testScript
+  log.stderr(`Picking script "${scriptName}" from package.json`)
+  return scriptName
+}
+
+async function buildPackageManagerTestCommand(testScriptName: string): Promise<[string, string[]]> {
+  // TODO: check if executables actually exist
+  if (await exists(path.resolve('yarn.lock'))) {
+    log.stderr(`Found yarn.lock file, invoking script "${testScriptName}" using yarn...`)
+    return ['yarn', [testScriptName]]
+  }
+  log.stderr(`Invoking script "${testScriptName}" using npm...`)
+  return ['npm', ['run', testScriptName, '--']]
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch (e) {
+    return false
+  }
+}

--- a/packages/codeaws-test-adapter-jest/src/index.ts
+++ b/packages/codeaws-test-adapter-jest/src/index.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import runCommand from './runCommand'
+import log from './log'
+import buildBaseTestCommand from './buildBaseTestCommand'
+
+import { AdapterInput, AdapterOutput } from '@sentinel-internal/codeaws-test-runner'
+
+export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+  const [executable, args] = await buildBaseTestCommand()
+  const testNamesToRun = testsToRun.map(({ testName }) => testName)
+  if (testNamesToRun.length > 0) {
+    args.push('--testNamePattern', testNamesToRun.join('|'))
+  }
+  log.stderr(`Running tests with jest using command: ${[executable, ...args].join(' ')}`)
+  const { status } = await runCommand(executable, args)
+  return { exitCode: status ?? 1 }
+}

--- a/packages/codeaws-test-adapter-jest/src/log.ts
+++ b/packages/codeaws-test-adapter-jest/src/log.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-console */
+
+interface Logger {
+  stderr(...args: any[]): void
+}
+
+class CodeAwsTestAdapterJestLogger implements Logger {
+  stderr(...args: any[]): void {
+    console.error('[codeaws-test-adapter-jest]:', ...args)
+  }
+}
+
+export default new CodeAwsTestAdapterJestLogger()

--- a/packages/codeaws-test-adapter-jest/src/runCommand.ts
+++ b/packages/codeaws-test-adapter-jest/src/runCommand.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'child_process'
+
+interface CommandResult {
+  status: number | null
+}
+
+// Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
+export default function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  const { status } = spawnSync(executable, args, { stdio: 'inherit' })
+
+  return Promise.resolve({ status })
+}

--- a/packages/codeaws-test-adapter-jest/tests/index.test.ts
+++ b/packages/codeaws-test-adapter-jest/tests/index.test.ts
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock('../src/log')
+
+describe('Jest adapter', () => {
+  it('executes jest when given tests to run', async () => {
+    jest.doMock('../src/buildBaseTestCommand', () => () => ['./node_modules/.bin/jest', []])
+
+    const runCommand = jest.fn(() => ({ status: 0 }))
+    jest.doMock('../src/runCommand', () => runCommand)
+
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests({
+      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(runCommand).toHaveBeenCalledWith('./node_modules/.bin/jest', [
+      '--testNamePattern',
+      'bill|bob|mary',
+    ])
+  })
+})


### PR DESCRIPTION
## Description

Adds jest adapter for executing tests with Jest. The "auto-inference" stuff is mostly speculative based on specific npm/yarn setups, but I think it would work pretty well for most use cases.

NB: this is a retroactive PR to get feedback as we move out of the prototyping phase.

## Testing

Tested adapter locally in sample jest projects.

## Checklist

I have:
* [x] Added new automated tests for any new functionality

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
