### PR TITLE
Add pytest adapter

### DIFF
--- a/packages/codeaws-test-adapter-pytest/src/index.ts
+++ b/packages/codeaws-test-adapter-pytest/src/index.ts
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import runCommand from './runCommand'
+import log from './log'
+
+import { AdapterInput, AdapterOutput } from '@sentinel-internal/codeaws-test-runner'
+
+export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+  const executable = 'pytest'
+  const args = []
+  const testNamesToRun = testsToRun.map(({ testName }) => testName)
+  if (testNamesToRun.length > 0) {
+    args.push('-k', `${testNamesToRun.join(' or ')}`)
+  }
+
+  // spawnSync will automatically quote any args with spaces in them, so we don't need to
+  // manually include the quotes when running the command. Here we do it for display purposes.
+  const quotedArgs = args.map((arg) => (arg.includes(' ') ? `'${arg}'` : arg))
+  log.stderr(`Running tests with pytest using command: ${[executable, ...quotedArgs].join(' ')}`)
+
+  const { status } = await runCommand(executable, args)
+  return { exitCode: status ?? 1 }
+}

--- a/packages/codeaws-test-adapter-pytest/src/log.ts
+++ b/packages/codeaws-test-adapter-pytest/src/log.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-console */
+
+interface Logger {
+  stderr(...args: any[]): void
+}
+
+class CodeAwsTestAdapterPytestLogger implements Logger {
+  stderr(...args: any[]): void {
+    console.error('[codeaws-test-adapter-pytest]:', ...args)
+  }
+}
+
+export default new CodeAwsTestAdapterPytestLogger()

--- a/packages/codeaws-test-adapter-pytest/src/runCommand.ts
+++ b/packages/codeaws-test-adapter-pytest/src/runCommand.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'child_process'
+
+interface CommandResult {
+  status: number | null
+}
+
+// Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
+export default function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  const { status } = spawnSync(executable, args, { stdio: 'inherit' })
+
+  return Promise.resolve({ status })
+}

--- a/packages/codeaws-test-adapter-pytest/tests/index.test.ts
+++ b/packages/codeaws-test-adapter-pytest/tests/index.test.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock('../src/log')
+
+describe('Pytest adapter', () => {
+  it('executes pytest when given tests to run', async () => {
+    const runCommand = jest.fn(() => ({ status: 0 }))
+    jest.doMock('../src/runCommand', () => runCommand)
+
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests({
+      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(runCommand).toHaveBeenCalledWith('pytest', ['-k', 'bill or bob or mary'])
+  })
+})


### PR DESCRIPTION
## Description

Adds a very simple pytest adapter to invoke tests with pytest. Pytest doesn't have a great way to run by individual test names, so using the -k option for now. I think this should almost definitely be changed in the future since this approach will likely match more tests than intended.

## Testing

Tested locally with test runner using example python project with pytest in a virtualenv.

## Checklist

I have:
* [x] Added new automated tests for any new functionality

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
