### PR TITLE
Add maven adapter

### DIFF
--- a/packages/codeaws-test-adapter-maven/src/index.ts
+++ b/packages/codeaws-test-adapter-maven/src/index.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import runCommand from './runCommand'
+import log from './log'
+
+import { AdapterInput, AdapterOutput } from '@sentinel-internal/codeaws-test-runner'
+
+export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+  const executable = 'mvn'
+  const args = []
+  const testNamesToRun = testsToRun.map(({ testName }) => testName)
+  if (testNamesToRun.length > 0) {
+    args.push(`-Dtest=${testNamesToRun.map((name) => `#${name}`).join(',')}`)
+  }
+  args.push('test')
+  log.stderr(`Running tests with maven using command: ${[executable, ...args].join(' ')}`)
+  const { status } = await runCommand(executable, args)
+  return { exitCode: status ?? 1 }
+}

--- a/packages/codeaws-test-adapter-maven/src/log.ts
+++ b/packages/codeaws-test-adapter-maven/src/log.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-console */
+
+interface Logger {
+  stderr(...args: any[]): void
+}
+
+class CodeAwsTestAdapterMavenLogger implements Logger {
+  stderr(...args: any[]): void {
+    console.error('[codeaws-test-adapter-maven]:', ...args)
+  }
+}
+
+export default new CodeAwsTestAdapterMavenLogger()

--- a/packages/codeaws-test-adapter-maven/src/runCommand.ts
+++ b/packages/codeaws-test-adapter-maven/src/runCommand.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'child_process'
+
+interface CommandResult {
+  status: number | null
+}
+
+// Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
+export default function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  const { status } = spawnSync(executable, args, { stdio: 'inherit' })
+
+  return Promise.resolve({ status })
+}

--- a/packages/codeaws-test-adapter-maven/tests/index.test.ts
+++ b/packages/codeaws-test-adapter-maven/tests/index.test.ts
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock('../src/log')
+
+describe('Maven adapter', () => {
+  it('executes maven when given tests to run', async () => {
+    const runCommand = jest.fn(() => ({ status: 0 }))
+    jest.doMock('../src/runCommand', () => runCommand)
+
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests({
+      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(runCommand).toHaveBeenCalledWith('mvn', ['-Dtest=#bill,#bob,#mary', 'test'])
+  })
+})


### PR DESCRIPTION
## Description

Adds a very simple maven adapter. I think we'll likely have to expand the pattern matching to support class names in addition to test names.

## Testing

Tested locally with runner CLI in sample maven project.

## Checklist

I have:
* [x] Added new automated tests for any new functionality

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
