### PR TITLE
Add gradle adapter

### DIFF
--- a/packages/codeaws-test-adapter-gradle/src/index.ts
+++ b/packages/codeaws-test-adapter-gradle/src/index.ts
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import runCommand from './runCommand'
+import log from './log'
+
+import { AdapterInput, AdapterOutput } from '@sentinel-internal/codeaws-test-runner'
+
+export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+  const executable = 'gradle'
+  const args = ['test']
+  const testNamesToRun = testsToRun.map(({ testName }) => testName)
+  if (testNamesToRun.length > 0) {
+    args.push(...testNamesToRun.flatMap((testName) => ['--tests', `*${testName}`]))
+  }
+  log.stderr(`Running tests with gradle using command: ${[executable, ...args].join(' ')}`)
+  const { status } = await runCommand(executable, args)
+  return { exitCode: status ?? 1 }
+}

--- a/packages/codeaws-test-adapter-gradle/src/log.ts
+++ b/packages/codeaws-test-adapter-gradle/src/log.ts
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable no-console */
+
+interface Logger {
+  stderr(...args: any[]): void
+}
+
+class CodeAwsTestAdapterGradleLogger implements Logger {
+  stderr(...args: any[]): void {
+    console.error('[codeaws-test-adapter-gradle]:', ...args)
+  }
+}
+
+export default new CodeAwsTestAdapterGradleLogger()

--- a/packages/codeaws-test-adapter-gradle/src/runCommand.ts
+++ b/packages/codeaws-test-adapter-gradle/src/runCommand.ts
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { spawnSync } from 'child_process'
+
+interface CommandResult {
+  status: number | null
+}
+
+// Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
+export default function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  const { status } = spawnSync(executable, args, { stdio: 'inherit' })
+
+  return Promise.resolve({ status })
+}

--- a/packages/codeaws-test-adapter-gradle/tests/index.test.ts
+++ b/packages/codeaws-test-adapter-gradle/tests/index.test.ts
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock('../src/log')
+
+describe('Gradle adapter', () => {
+  it('executes gradle when given tests to run', async () => {
+    const runCommand = jest.fn(() => ({ status: 0 }))
+    jest.doMock('../src/runCommand', () => runCommand)
+
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests({
+      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(runCommand).toHaveBeenCalledWith('gradle', [
+      'test',
+      '--tests',
+      '*bill',
+      '--tests',
+      '*bob',
+      '--tests',
+      '*mary',
+    ])
+  })
+})


### PR DESCRIPTION
## Description

Adds a very simple gradle adapter -- we'll have to support class names in the future, similar to the maven adapter; only method names are used right now.

## Testing

Tested locally with test runner in example gradle project

## Checklist

I have:
* [x] Added new automated tests for any new functionality

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
