### PR TITLE
chore: Fix test

### DIFF
--- a/tests/package-lock.test.ts
+++ b/tests/package-lock.test.ts
@@ -6,7 +6,10 @@ import path from 'path'
 
 describe('package-lock.json', () => {
   it('does not include any codeartifact URLs', () => {
-    const packageLockJson = fs.readFileSync(path.join(__dirname, '..', 'package-lock.json'))
+    const packageLockJson = fs.readFileSync(
+      path.join(__dirname, '..', 'package-lock.json'),
+      'utf-8',
+    )
     expect(packageLockJson).not.toContain('codeartifact')
   })
 })


### PR DESCRIPTION
## Description

Checking .toContain on a Buffer instead of a string 😛 

## Testing

* Confirmed that test fails when package-lock contains a codeartifact URL ✅ 

## Checklist

I have:
* 🙅 Added new automated tests for any new functionality

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
