### PR TITLE
feat: Add CLI positionals and examples

### DIFF
--- a/packages/universal-test-runner/src/loadAdapter.ts
+++ b/packages/universal-test-runner/src/loadAdapter.ts
@@ -6,15 +6,16 @@ import path from 'path'
 
 import { Adapter } from '@sentinel-internal/universal-test-runner-types'
 
+export const builtInAdapters: { [key: string]: string } = {
+  jest: '@sentinel-internal/universal-test-adapter-jest',
+  maven: '@sentinel-internal/universal-test-adapter-maven',
+  gradle: '@sentinel-internal/universal-test-adapter-gradle',
+  pytest: '@sentinel-internal/universal-test-adapter-pytest',
+  dotnet: '@sentinel-internal/universal-test-adapter-dotnet',
+} as const
+
 export async function loadAdapter(rawAdapterModule: string, cwd: string): Promise<Adapter> {
-  const adapterModule =
-    {
-      jest: '@sentinel-internal/universal-test-adapter-jest',
-      maven: '@sentinel-internal/universal-test-adapter-maven',
-      gradle: '@sentinel-internal/universal-test-adapter-gradle',
-      pytest: '@sentinel-internal/universal-test-adapter-pytest',
-      dotnet: '@sentinel-internal/universal-test-adapter-dotnet',
-    }[rawAdapterModule] || rawAdapterModule
+  const adapterModule = builtInAdapters[rawAdapterModule] || rawAdapterModule
 
   try {
     const adapterImportPath = adapterModule.startsWith('.')

--- a/packages/universal-test-runner/tests/builtInAdapters.test.ts
+++ b/packages/universal-test-runner/tests/builtInAdapters.test.ts
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { builtInAdapters } from '../src/loadAdapter'
+
+import packageJson from '../package.json'
+
+test.each(Object.entries(builtInAdapters))(
+  'Package has %s adapter listed as a dependency',
+  (adapterName, adapterPackage) => {
+    expect(Object.keys(packageJson.dependencies)).toContain(adapterPackage)
+  },
+)

--- a/packages/universal-test-runner/tsconfig.json
+++ b/packages/universal-test-runner/tsconfig.json
@@ -13,7 +13,8 @@
     "alwaysStrict": true,
     "noImplicitReturns": true,
     "inlineSourceMap": true,
-    "inlineSources": true
+    "inlineSources": true,
+    "resolveJsonModule": true
   },
   "include": ["bin", "src", "tests"]
 }


### PR DESCRIPTION
## Description

Before 👎:
```
Usage: run-tests <adapter> [args]

Options:
  -v, --version  Show version number                                   [boolean]
  -h, --help     Show help                                             [boolean]
```

After 💯:
```
run-tests <adapter|packageName|adapterPath>

Run tests according to the Test Execution Protocol

Positionals:
  adapter      The name of a built-in adapter (jest,maven,gradle,pytest,dotnet)
                                                                        [string]
  packageName  The package name of a third-party adapter                [string]
  adapterPath  The file path to a custom adapter                        [string]

Options:
  -v, --version  Show version number                                   [boolean]
  -h, --help     Show help                                             [boolean]

Examples:
  run-tests jest                 Run tests with a built-in adapter
  run-tests my-adapter-from-npm  Run tests with a third-party adapter
  run-tests ./my-adapter.js      Run tests with a custom adapter
```

## Testing

* Confirmed that `--help` text is correct ✅ 
* Confirmed that all unit tests pass ✅ 

## Checklist

I have:
* ❌ Added new automated tests for any new functionality
* ❌ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
