### PR TITLE
chore: Match @types/node version to Node.js version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@commitlint/cli": "^17.2.0",
         "@commitlint/config-conventional": "^17.3.0",
         "@types/jest": "^29.2.4",
-        "@types/node": "^18.11.15",
+        "@types/node": "^16",
         "@typescript-eslint/eslint-plugin": "^5.46.0",
         "@typescript-eslint/parser": "^5.45.1",
         "babel-jest": "^29.3.1",
@@ -2785,9 +2785,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
-      "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==",
+      "version": "16.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.10.tgz",
+      "integrity": "sha512-XU1+v7h81p7145ddPfjv7jtWvkSilpcnON3mQ+bDi9Yuf7OI56efOglXRyXWgQ57xH3fEQgh7WOJMncRHVew5w==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -9661,9 +9661,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
-      "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw==",
+      "version": "16.18.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.10.tgz",
+      "integrity": "sha512-XU1+v7h81p7145ddPfjv7jtWvkSilpcnON3mQ+bDi9Yuf7OI56efOglXRyXWgQ57xH3fEQgh7WOJMncRHVew5w==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@commitlint/cli": "^17.2.0",
     "@commitlint/config-conventional": "^17.3.0",
     "@types/jest": "^29.2.4",
-    "@types/node": "^18.11.15",
+    "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.45.1",
     "babel-jest": "^29.3.1",


### PR DESCRIPTION
## Description

The @types/node version should match the Node.js version, as described in the DefinitelyTyped README: https://github.com/definitelytyped/definitelytyped#how-do-definitely-typed-package-versions-relate-to-versions-of-the-corresponding-library

This does bring up an interesting question for matrix builds -- what happens when we run builds with Node.js 14.x and 18.x? Should we manually install @types/node 14.x and 18.x in those builds? For now I think the answer is "don't worry about it":
* We run matrix builds to detect possible version incompatibilities with our code and Node.js, making sure our package supports LTS versions of Node.js
* Type checking should only fail if there are incompatibilities (breaking changes) between versions of Node.js which caused the types to be updated to something new
* Therefore, type checking should only fail if the matrix build would have failed anyway (at runtime), so manually installing different versions of the @types/node package is redundant

## Testing

* Confirmed that tsc still succeeds ✅ 

## Checklist

I have:
* 🙅 Added new automated tests for any new functionality
* 🙅 Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
