### PR TITLE
build: Add Dockerfile with all integ test dependencies

### DIFF
--- a/.codecatalyst/workflows/universal-test-runner.yaml
+++ b/.codecatalyst/workflows/universal-test-runner.yaml
@@ -31,5 +31,25 @@ Actions:
         - Run: npm ci
         - Run: npm run build
         - Run: COMMIT_ID=${WorkflowSource.CommitId} npm run bump:prerelease
-        - Run: aws codeartifact login --tool npm --repository codeaws-sentinel-internal --domain codeaws-sentinel-internal --domain-owner ${Secrets.CodeArtifactPublishAccountId-XGKTb5} --region us-west-2
+        - Run: aws codeartifact login --tool npm --repository ${Secrets.CodeArtifactRepository} --domain ${Secrets.CodeArtifactDomain} --domain-owner ${Secrets.CodeArtifactDomainOwner} --region us-west-2
         - Run: npm publish --workspaces --unsafe-perm
+
+  PushToDocker:
+    Identifier: aws/build@v1
+
+    DependsOn:
+      - BuildAndPublish
+
+    Inputs:
+      Sources:
+        - WorkflowSource
+
+    Environment:
+      Name: EcrDockerInternalPublish
+      Connections:
+        - Role: codecatalyst-UniversalTestRunnerDockerPush
+          Name: codeawsstart_developer-testing
+
+    Configuration:
+      Steps:
+        - Run: DOMAIN=${Secrets.CodeArtifactDomain} DOMAIN_OWNER=${Secrets.CodeArtifactDomainOwner} REPOSITORY=${Secrets.CodeArtifactRepository} ECR_REGISTRY=${Secrets.EcrRegistry} bash docker-build.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+**/dotnet/bin/
+**/dotnet/obj/
+
+**/gradle/.gradle
+**/gradle/build
+
+**/jest/node_modules
+
+**/maven/target
+
+**/pytest/venv
+**/pytest/__pycache__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+FROM node:16
+
+# https://stackoverflow.com/questions/20635472/using-the-run-instruction-in-a-dockerfile-with-source-does-not-work
+SHELL ["/bin/bash", "-c"]
+
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian#debian-11
+RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN rm packages-microsoft-prod.deb
+
+RUN apt update
+
+RUN apt install -y default-jre default-jdk
+RUN java -version
+
+RUN apt install -y maven
+RUN mvn --version
+
+# https://gradle.org/install/#with-a-package-manager
+RUN apt install -y zip
+RUN curl -s "https://get.sdkman.io" | bash
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk version
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install gradle 7.6
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && gradle --version
+
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian#install-the-sdk
+RUN apt install -y dotnet-sdk-6.0
+RUN dotnet --version
+
+RUN node --version
+
+# Python is already install, but need python3-venv on debian to create venvs
+RUN apt install -y python3-venv
+RUN python3 --version
+
+RUN --mount=type=secret,id=universal_test_runner_registry,target=universal_test_runner_registry \
+  --mount=type=secret,id=universal_test_runner_auth_token,target=universal_test_runner_auth_token \
+  npm install -g @sentinel-internal/universal-test-runner \
+  --registry=https://$(cat universal_test_runner_registry) \
+  --//$(cat universal_test_runner_registry):_authToken=$(cat universal_test_runner_auth_token)
+RUN run-tests --version
+
+WORKDIR universal-test-runner
+
+COPY tests-integ/test-projects .
+
+RUN cd jest && bash setup.sh && RUN_TESTS=run-tests bash run.sh
+RUN cd pytest && bash setup.sh && RUN_TESTS=run-tests bash run.sh
+RUN cd maven && bash setup.sh && RUN_TESTS=run-tests bash run.sh
+RUN cd gradle && source "$HOME/.sdkman/bin/sdkman-init.sh" && bash setup.sh && RUN_TESTS=run-tests bash run.sh
+RUN cd dotnet && bash setup.sh && RUN_TESTS=run-tests bash run.sh

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -e
+
+ENDPOINT_FILE=$(mktemp)
+TOKEN_FILE=$(mktemp)
+
+[[ -z "$DOMAIN" ]] && echo "No DOMAIN provided!" && exit 1
+[[ -z "$DOMAIN_OWNER" ]] && echo "No DOMAIN_OWNER provided!" && exit 1
+[[ -z "$REPOSITORY" ]] && echo "No REPOSITORY provided!" && exit 1
+[[ -z "$ECR_REGISTRY" ]] && echo "No ECR_REGISTRY provided!" && exit 1
+
+aws codeartifact get-repository-endpoint --region us-west-2 --domain $DOMAIN --domain-owner $DOMAIN_OWNER --repository $REPOSITORY --format npm --output text | sed 's/https:\/\///' > $ENDPOINT_FILE
+
+aws codeartifact get-authorization-token --region us-west-2 --domain $DOMAIN  --domain-owner $DOMAIN_OWNER --query authorizationToken --output text > $TOKEN_FILE
+
+DOCKER_BUILDKIT=1 docker build -t universal-test-runner . \
+  --secret id=universal_test_runner_registry,src=$ENDPOINT_FILE \
+  --secret id=universal_test_runner_auth_token,src=$TOKEN_FILE
+
+rm $ENDPOINT_FILE
+rm $TOKEN_FILE
+
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ECR_REGISTRY
+
+docker tag universal-test-runner:latest $ECR_REGISTRY:latest
+docker push $ECR_REGISTRY:latest

--- a/tests-integ/test-projects/jest/.gitignore
+++ b/tests-integ/test-projects/jest/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-reports

--- a/tests-integ/test-projects/pytest/script/bootstrap.sh
+++ b/tests-integ/test-projects/pytest/script/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
## Description

Adds a Dockerfile as a way of documenting the dependencies needed for running integration tests. Also builds and publishes the images to an ECR repo (private for now) via CodeCatalyst. The universal-test-runner executable is installed and baked into the image so you can just drop into bash in the docker image to test out all the adapters without any additional setup.

## Testing

* Built the docker image locally and confirmed that all adapters run tests correctly ✅ 

## Checklist

I have:
* 🙅 Added new automated tests for any new functionality
* 🙅 Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
