### PR TITLE
build: Split out script for docker push

### DIFF
--- a/.codecatalyst/workflows/universal-test-runner.yaml
+++ b/.codecatalyst/workflows/universal-test-runner.yaml
@@ -52,4 +52,5 @@ Actions:
 
     Configuration:
       Steps:
-        - Run: DOMAIN=${Secrets.CodeArtifactDomain} DOMAIN_OWNER=${Secrets.CodeArtifactDomainOwner} REPOSITORY=${Secrets.CodeArtifactRepository} ECR_REGISTRY=${Secrets.EcrRegistry} bash docker-build.sh
+        - Run: DOMAIN=${Secrets.CodeArtifactDomain} DOMAIN_OWNER=${Secrets.CodeArtifactDomainOwner} REPOSITORY=${Secrets.CodeArtifactRepository} bash docker-build.sh
+        - Run: ECR_REGISTRY=${Secrets.EcrRegistry} bash docker-push.sh

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -8,7 +8,6 @@ TOKEN_FILE=$(mktemp)
 [[ -z "$DOMAIN" ]] && echo "No DOMAIN provided!" && exit 1
 [[ -z "$DOMAIN_OWNER" ]] && echo "No DOMAIN_OWNER provided!" && exit 1
 [[ -z "$REPOSITORY" ]] && echo "No REPOSITORY provided!" && exit 1
-[[ -z "$ECR_REGISTRY" ]] && echo "No ECR_REGISTRY provided!" && exit 1
 
 aws codeartifact get-repository-endpoint --region us-west-2 --domain $DOMAIN --domain-owner $DOMAIN_OWNER --repository $REPOSITORY --format npm --output text | sed 's/https:\/\///' > $ENDPOINT_FILE
 
@@ -20,8 +19,3 @@ DOCKER_BUILDKIT=1 docker build -t universal-test-runner . \
 
 rm $ENDPOINT_FILE
 rm $TOKEN_FILE
-
-aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ECR_REGISTRY
-
-docker tag universal-test-runner:latest $ECR_REGISTRY:latest
-docker push $ECR_REGISTRY:latest

--- a/docker-push.sh
+++ b/docker-push.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+[[ -z "$ECR_REGISTRY" ]] && echo "No ECR_REGISTRY provided!" && exit 1
+
+aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin $ECR_REGISTRY
+
+docker tag universal-test-runner:latest $ECR_REGISTRY:latest
+docker push $ECR_REGISTRY:latest


### PR DESCRIPTION
## Description

Moves the docker push command into its own script.

## Testing

* Confirmed that build script still succeeds and does not do the push. Will test the push in CodeCatalyst after merge ✅ 

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* 🙅‍♀️ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
