### PR TITLE
fix: Handle errors from spawnSync in all adapters

### DIFF
--- a/packages/universal-test-adapter-dotnet/src/index.ts
+++ b/packages/universal-test-adapter-dotnet/src/index.ts
@@ -15,6 +15,9 @@ export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<A
     args.push(`${testNamesToRun.map((name) => `(FullyQualifiedName=${name})`).join(' | ')}`)
   }
   log.info(`Running tests with dotnet test using command: ${[executable, ...args].join(' ')}`)
-  const { status } = await runCommand(executable, args)
+  const { status, error } = await runCommand(executable, args)
+  if (error) {
+    log.error(error)
+  }
   return { exitCode: status ?? 1 }
 }

--- a/packages/universal-test-adapter-dotnet/src/runCommand.ts
+++ b/packages/universal-test-adapter-dotnet/src/runCommand.ts
@@ -5,11 +5,12 @@ import { spawnSync } from 'child_process'
 
 interface CommandResult {
   status: number | null
+  error?: Error
 }
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
-  const result = spawnSync(executable, args, { stdio: 'inherit' })
+  const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
-  return Promise.resolve({ status: result.status })
+  return Promise.resolve({ status, error })
 }

--- a/packages/universal-test-adapter-gradle/src/index.ts
+++ b/packages/universal-test-adapter-gradle/src/index.ts
@@ -24,6 +24,9 @@ export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<A
     )
   }
   log.info(`Running tests with gradle using command: ${[executable, ...args].join(' ')}`)
-  const { status } = await runCommand(executable, args)
+  const { status, error } = await runCommand(executable, args)
+  if (error) {
+    log.error(error)
+  }
   return { exitCode: status ?? 1 }
 }

--- a/packages/universal-test-adapter-gradle/src/runCommand.ts
+++ b/packages/universal-test-adapter-gradle/src/runCommand.ts
@@ -5,11 +5,12 @@ import { spawnSync } from 'child_process'
 
 interface CommandResult {
   status: number | null
+  error?: Error
 }
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
-  const { status } = spawnSync(executable, args, { stdio: 'inherit' })
+  const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
-  return Promise.resolve({ status })
+  return Promise.resolve({ status, error })
 }

--- a/packages/universal-test-adapter-jest/src/index.ts
+++ b/packages/universal-test-adapter-jest/src/index.ts
@@ -16,14 +16,13 @@ export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<A
     args.push('--testNamePattern', testNamesToRun.join('|'))
   }
 
-  const extraEnvVars: { [key: string]: string } = {}
+  log.info(`Running tests with jest using command: ${[executable, ...args].join(' ')}`)
 
-  const envVarStrings = Object.entries(extraEnvVars).map(([key, value]) => `${key}="${value}"`)
+  const { status, error } = await runCommand(executable, args)
 
-  log.info(
-    `Running tests with jest using command: ${[...envVarStrings, executable, ...args].join(' ')}`,
-  )
+  if (error) {
+    log.error(error)
+  }
 
-  const { status } = await runCommand(executable, args, extraEnvVars)
   return { exitCode: status ?? 1 }
 }

--- a/packages/universal-test-adapter-jest/src/runCommand.ts
+++ b/packages/universal-test-adapter-jest/src/runCommand.ts
@@ -5,18 +5,12 @@ import { spawnSync } from 'child_process'
 
 interface CommandResult {
   status: number | null
+  error?: Error
 }
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
-export function runCommand(
-  executable: string,
-  args: string[],
-  extraEnvVars = {},
-): Promise<CommandResult> {
-  const { status } = spawnSync(executable, args, {
-    stdio: 'inherit',
-    env: { ...process.env, ...extraEnvVars },
-  })
+export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
-  return Promise.resolve({ status })
+  return Promise.resolve({ status, error })
 }

--- a/packages/universal-test-adapter-jest/tests/index.test.ts
+++ b/packages/universal-test-adapter-jest/tests/index.test.ts
@@ -19,10 +19,9 @@ describe('Jest adapter', () => {
     })
 
     expect(exitCode).toBe(0)
-    expect(runCommand).toHaveBeenCalledWith(
-      './node_modules/.bin/jest',
-      ['--testNamePattern', 'bill|bob|mary'],
-      {},
-    )
+    expect(runCommand).toHaveBeenCalledWith('./node_modules/.bin/jest', [
+      '--testNamePattern',
+      'bill|bob|mary',
+    ])
   })
 })

--- a/packages/universal-test-adapter-maven/src/index.ts
+++ b/packages/universal-test-adapter-maven/src/index.ts
@@ -15,6 +15,9 @@ export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<A
   }
   args.push('test')
   log.info(`Running tests with maven using command: ${[executable, ...args].join(' ')}`)
-  const { status } = await runCommand(executable, args)
+  const { status, error } = await runCommand(executable, args)
+  if (error) {
+    log.error(error)
+  }
   return { exitCode: status ?? 1 }
 }

--- a/packages/universal-test-adapter-maven/src/runCommand.ts
+++ b/packages/universal-test-adapter-maven/src/runCommand.ts
@@ -5,11 +5,12 @@ import { spawnSync } from 'child_process'
 
 interface CommandResult {
   status: number | null
+  error?: Error
 }
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
-  const { status } = spawnSync(executable, args, { stdio: 'inherit' })
+  const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
-  return Promise.resolve({ status })
+  return Promise.resolve({ status, error })
 }

--- a/packages/universal-test-runner/src/run.ts
+++ b/packages/universal-test-runner/src/run.ts
@@ -25,9 +25,12 @@ export async function run(
     log.info('Calling executeTests on adapter...')
     const adapterOutput = await adapter.executeTests(adapterInput)
     log.info('Finished executing tests.')
+    if (adapterOutput.exitCode !== 0) {
+      log.error(`Test run failed with exit code ${adapterOutput.exitCode}`)
+    }
     return adapterOutput
   } catch (e) {
-    log.error('Failed to run tests.', e)
+    log.error('Failed to run tests due to an adapter error.', e)
     return { exitCode: ErrorCodes.ADAPTER_ERROR }
   }
 }


### PR DESCRIPTION
## Description

We were already doing this in the pytest adapter, and this just ports the dead simplest change to the other adapters as well. Even more reason to have a common spawnSync helper. This makes error output much more obvious when, for example, and executable doesn't exist.

## Testing

* Confirmed that all tests pass ✅

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
