### PR TITLE
ci: Add semgrep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug
-          
+
   semgrep:
     runs-on: ubuntu-latest
 
@@ -78,7 +78,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - run: semgrep --config "p/default" packages
-      #- run: semgrep ci --include packages
-        #env:
-        #   SEMGREP_RULES: "p/default" # more at semgrep.dev/explore
+      - run: semgrep ci --include packages
+        env:
+           SEMGREP_RULES: "p/default"

--- a/packages/universal-test-adapter-dotnet/src/runCommand.ts
+++ b/packages/universal-test-adapter-dotnet/src/runCommand.ts
@@ -10,6 +10,7 @@ interface CommandResult {
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
   const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
   return Promise.resolve({ status, error })

--- a/packages/universal-test-adapter-gradle/src/runCommand.ts
+++ b/packages/universal-test-adapter-gradle/src/runCommand.ts
@@ -10,6 +10,7 @@ interface CommandResult {
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
   const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
   return Promise.resolve({ status, error })

--- a/packages/universal-test-adapter-jest/src/runCommand.ts
+++ b/packages/universal-test-adapter-jest/src/runCommand.ts
@@ -10,6 +10,7 @@ interface CommandResult {
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
   const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
   return Promise.resolve({ status, error })

--- a/packages/universal-test-adapter-maven/src/runCommand.ts
+++ b/packages/universal-test-adapter-maven/src/runCommand.ts
@@ -10,6 +10,7 @@ interface CommandResult {
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
   const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
   return Promise.resolve({ status, error })

--- a/packages/universal-test-adapter-pytest/src/runCommand.ts
+++ b/packages/universal-test-adapter-pytest/src/runCommand.ts
@@ -10,6 +10,7 @@ interface CommandResult {
 
 // Return an promise since we're likely to change from spawnSync to spawn (or something else async) at some point
 export function runCommand(executable: string, args: string[]): Promise<CommandResult> {
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
   const { status, error } = spawnSync(executable, args, { stdio: 'inherit' })
 
   return Promise.resolve({ status, error })

--- a/packages/universal-test-runner/src/loadAdapter.ts
+++ b/packages/universal-test-runner/src/loadAdapter.ts
@@ -19,7 +19,7 @@ export async function loadAdapter(rawAdapterModule: string, cwd: string): Promis
 
   try {
     const adapterImportPath = adapterModule.startsWith('.')
-      ? path.join(cwd, adapterModule)
+      ? resolveCustomAdapterPath(cwd, adapterModule)
       : adapterModule
     const adapter = await import(adapterImportPath)
     log.info('Loaded adapter from', adapterModule)
@@ -28,4 +28,9 @@ export async function loadAdapter(rawAdapterModule: string, cwd: string): Promis
     log.error('Failed to load adapter from', adapterModule)
     throw e
   }
+}
+
+function resolveCustomAdapterPath(cwd: string, adapterPath: string): string {
+  // nosemgrep: javascript.lang.security.audit.path-traversal.path-join-resolve-traversal.path-join-resolve-traversal
+  return path.join(cwd, adapterPath)
 }


### PR DESCRIPTION
## Description

Adds semgrep for security scanning. Disables the tolerable ones for now -- we really need to consolidate usages of spawn 😅 As noted in #133 

## Testing

* Running CI on PR
* Ran semgrep locally and confirmed that there are no errors

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* 🙅‍♀️ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
