### PR TITLE
build: Fix prerelease script

### DIFF
--- a/scripts/bump-prerelease.sh
+++ b/scripts/bump-prerelease.sh
@@ -6,7 +6,7 @@ set -e
 
 echo "Bumping all packages to version $PRERELEASE_VERSION"
 
-npm version $PRERELEASE_VERSION --workspaces --no-workspaces-update --no-git-tag-version
+npm version $PRERELEASE_VERSION --workspaces --no-workspaces-update --include-workspace-root --no-git-tag-version
 
 npx ts-node ./scripts/update-dependency-versions
 
@@ -15,6 +15,6 @@ echo "Replacing all usage of @aws scope with @sentinel-internal..."
 # Replace all usage of aws scope with sentinel-internal in order to publish
 # prereleases to internal CodeArtifact registry for testing purposes.
 # Note that a space is required after -i on some systems, e.g. `sed -i '' -e ...`
-sed -i'' -e 's/@sentinel-internal/@sentinel-internal/g' $(grep -l -R @sentinel-internal --exclude="*node_modules*" --exclude="*dist*" .)
+sed -i'' -e 's/@aws/@sentinel-internal/g' $(grep -l -R @sentinel-internal --exclude="*node_modules*" --exclude="*dist*" .)
 
 echo "Done."


### PR DESCRIPTION
## Description

Fixes version test, and looks like the prerelease script replaced its own `@aws` and somehow crept into the renaming PR 😅 

## Testing

* None yet, will check CodeCatalyst build once this is merged

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* 🙅‍♀️ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
