### PR TITLE
build: Run CodeCatalyst build on ubuntu

### DIFF
--- a/.codecatalyst/workflows/universal-test-runner.yaml
+++ b/.codecatalyst/workflows/universal-test-runner.yaml
@@ -35,6 +35,9 @@ Actions:
         - Run: npm test # re-run tests after we prepare the prerelease to make sure we did everything correctly
         - Run: aws codeartifact login --tool npm --repository ${Secrets.CodeArtifactRepository} --domain ${Secrets.CodeArtifactDomain} --domain-owner ${Secrets.CodeArtifactDomainOwner} --region us-west-2
         - Run: npm publish --workspaces --unsafe-perm
+      Container:
+        Registry: DockerHub
+        Image: ubuntu:latest
 
   PushToDocker:
     Identifier: aws/build@v1


### PR DESCRIPTION
## Description

Node.js 18 doesn't have the needed dependencies installed on the default CodeCatalyst image, trying ubuntu instead

## Testing

None, will verify in CodeCatalyst after merge

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* 🙅‍♀️ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
