### PR TITLE
build: Use buildpack-deps docker image

### DIFF
--- a/.codecatalyst/workflows/universal-test-runner.yaml
+++ b/.codecatalyst/workflows/universal-test-runner.yaml
@@ -27,7 +27,12 @@ Actions:
 
     Configuration:
       Steps:
+        - Run: curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+        - Run: unzip awscliv2.zip
+        - Run: ./aws/install
         - Run: . ./setup-node.sh
+        - Run: node -v
+        - Run: npm -v
         - Run: npm ci
         - Run: npm run build
         - Run: COMMIT_ID=${WorkflowSource.CommitId} npm run bump:prerelease
@@ -37,7 +42,7 @@ Actions:
         - Run: npm publish --workspaces --unsafe-perm
       Container:
         Registry: DockerHub
-        Image: ubuntu:latest
+        Image: buildpack-deps:latest # Node.js 18 can't be installed in default curated image yet
 
   PushToDocker:
     Identifier: aws/build@v1

--- a/setup-node.sh
+++ b/setup-node.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-set -e
+# Can't use `set -e` here when running in buildpack-deps docker image,
+# possibly related to https://github.com/nvm-sh/nvm/issues/1985
+# set -e
 
 # Used to install the right Node.js (and NPM) version when running in some CI
 # environments When installing Node.js in your local dev env, use the


### PR DESCRIPTION
## Description

Follow up to #174, ubuntu didn't work so tested directly in CodeCatalyst this time.

## Testing

* Verified that build succeeds in CodeCatalyst ✅

## Checklist

I have:
* ✅ Added new automated tests for any new functionality
* 🙅‍♀️ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
