### PR TITLE
build: Fix docker build by removing sdkman libexec folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN mvn --version
 # https://gradle.org/install/#with-a-package-manager
 RUN apt install -y zip
 RUN curl -s "https://get.sdkman.io" | bash
+RUN rm -rf "$HOME/.sdkman/libexec" # Remove mysterious executables that break some sdkman commands
 RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk version
 RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install gradle 7.6
 RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && gradle --version


### PR DESCRIPTION
## Description

Not sure why the docker build started failing suddenly, but here is what I posted about my debugging steps in the sdkman slack:

> Hi all, getting some weird behaviour running the sdk version/help commands on a node:18 docker container, would be great if someone could shed some light:
>  `docker run -it node:18 /bin/bash`
> Then within docker, install sdkman:
> ``` 
> apt update
> apt install -y zip
> curl -s "https://get.sdkman.io/" | bash
> source "$HOME/.sdkman/bin/sdkman-init.sh"
> sdk version
> ```
> Fails with `GLIBC_2.33 not found` -- same error when I run the help or home commands, but the weird thing is that all the other sdk commands work fine. I can sdk install stuff no problem :sweat_smile:.
> Also, if I `rm -rf .sdkman/libexec`, all the commands start working fine again, version/help/home run no problem.
> So not an immediate blocker for me, but I'd like to understand why this started happening -- build just started failing for me and I can't find any changes in the docker base image or sdkman or my dockerfile that indicate why. Unsure why this libexec folder exists when installing sdkman as well. Thanks for any help
> 

## Testing

Modified Dockerfile in CodeCatalyst directly and verified that the workflow succeeds

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* 🙅‍♀️ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
