### PR TITLE
feat: Add pytest and dotnet reporting support

### DIFF
--- a/packages/universal-test-adapter-dotnet/tests/index.test.ts
+++ b/packages/universal-test-adapter-dotnet/tests/index.test.ts
@@ -63,4 +63,24 @@ describe('Dotnet adapter', () => {
         '(FullyQualifiedName~Company.ServerlessFunctions.UnitTests.ValuesControllerTests.TestGet5)',
     ])
   })
+
+  it('passes the right arguments for default report format', async () => {
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests({
+      testsToRun: [{ testName: 'TestGet' }],
+      reportFormat: 'default',
+    })
+
+    expect(exitCode).toBe(0)
+    expect(spawn).toHaveBeenCalledWith('dotnet', [
+      'test',
+      '--filter',
+      '(FullyQualifiedName~.TestGet)',
+      '--logger',
+      `trx;LogFileName=${process.cwd()}/results.trx`,
+      '--logger',
+      'console',
+    ])
+  })
 })

--- a/packages/universal-test-adapter-pytest/src/index.ts
+++ b/packages/universal-test-adapter-pytest/src/index.ts
@@ -6,7 +6,9 @@ import { log } from './log'
 
 import { AdapterInput, AdapterOutput } from '@aws/universal-test-runner-types'
 
-export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+export async function executeTests(input: AdapterInput): Promise<AdapterOutput> {
+  const { testsToRun = [], reportFormat } = input
+
   const executable = 'pytest'
   const args = []
 
@@ -34,6 +36,16 @@ export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<A
     matchTestsDirectly
       ? args.push('-v', `${testNamesToRun.join(' ')}`)
       : args.push('-k', `${testNamesToRun.join(' or ')}`)
+  }
+
+  switch (reportFormat) {
+    case 'default':
+      args.push('--junitxml=junit.xml')
+      break
+    case undefined:
+      break
+    default:
+      log.warn(`Report format ${reportFormat} not supported!`)
   }
 
   // spawnSync will automatically quote any args with spaces in them, so we don't need to

--- a/packages/universal-test-adapter-pytest/tests/index.test.ts
+++ b/packages/universal-test-adapter-pytest/tests/index.test.ts
@@ -59,4 +59,20 @@ describe('Pytest adapter', () => {
       'fileA.py::suiteA::bill fileB.py::suiteB::bob fileC.py::suiteC::mary',
     ])
   })
+
+  it('passes the correct arguments for report format', async () => {
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests({
+      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
+      reportFormat: 'default',
+    })
+
+    expect(exitCode).toBe(0)
+    expect(spawn).toHaveBeenCalledWith('pytest', [
+      '-k',
+      '(bill) or (bob) or (mary)',
+      '--junitxml=junit.xml',
+    ])
+  })
 })

--- a/tests-integ/reports.test.ts
+++ b/tests-integ/reports.test.ts
@@ -3,21 +3,37 @@
 
 import { runSetupScript, runCli, remove, readFile } from './helpers'
 
-describe('jest adapter', () => {
-  it('generates a report file', () => {
-    runSetupScript('jest')
+const ADAPTERS: [string, string, (contents: string) => boolean][] = [
+  ['jest', 'junit.xml', verifyJunitReport],
+  ['pytest', 'junit.xml', verifyJunitReport],
+  ['dotnet', 'results.trx', verifyTrxReport],
+]
 
-    const { status } = runCli('jest', {
+describe.each(ADAPTERS)('%s adapter', (adapter, reportFile, verifyReport) => {
+  it('generates a default report file', () => {
+    runSetupScript(adapter)
+
+    const { status } = runCli(adapter, {
       TEP_VERSION: '0.1.0',
       TEP_REPORT_FORMAT: 'default',
     })
     expect(status).toBe(0)
 
-    const report = readFile('jest', 'junit.xml')
-    expect(report).toContain('xml')
-    expect(report).toContain('testsuites')
-    expect(report).toContain('testcase')
+    const report = readFile(adapter, reportFile)
+    expect(verifyReport(report)).toBe(true)
 
-    remove('jest', 'junit.xml')
+    remove(adapter, reportFile)
   })
 })
+
+function verifyJunitReport(contents: string): boolean {
+  return (
+    contents.includes('xml') && contents.includes('testsuites') && contents.includes('testcase')
+  )
+}
+
+function verifyTrxReport(contents: string): boolean {
+  return (
+    contents.includes('xml') && contents.includes('TestRun') && contents.includes('UnitTestResult')
+  )
+}

--- a/tests-integ/test-projects/dotnet/.gitignore
+++ b/tests-integ/test-projects/dotnet/.gitignore
@@ -1,2 +1,3 @@
 bin/
 obj/
+TestResults


### PR DESCRIPTION
## Description

Resurrecting more of #189, and also adding support for dotnet report generation.

## Testing

* Confirmed unit and integ tests pass ✅
* Ran commands locally in integ tests projects to verify that reports were generated as expected ✅

## Checklist

I have:
* ✅ Added new automated tests for any new functionality
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
