### PR TITLE
build: Enable some more eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,9 @@ module.exports = {
   },
   rules: {
     eqeqeq: 'error',
+    'no-fallthrough': 'error',
+    'prefer-template': 'error',
+    'require-await': 'error',
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/no-empty-function': 'off',
@@ -44,6 +47,5 @@ module.exports = {
         message: 'Use named exports instead of default exports',
       },
     ],
-    'require-await': 'error',
   },
 }

--- a/packages/universal-test-adapter-dotnet/src/index.ts
+++ b/packages/universal-test-adapter-dotnet/src/index.ts
@@ -14,14 +14,14 @@ export const parseFilepathAndClassName = (
   suiteName: string | undefined,
 ): string => {
   if (!filepath) {
-    return '.' + suiteName || ''
+    return `.${suiteName}` || ''
   }
 
   const parsedPath = path.parse(filepath)
   if (suiteName && parsedPath.name !== suiteName) {
-    filepath = `${parsedPath.dir ? parsedPath.dir + '.' : ''}${parsedPath.name}.${suiteName}`
+    filepath = `${parsedPath.dir ? `${parsedPath.dir}.` : ''}${parsedPath.name}.${suiteName}`
   } else {
-    filepath = `${parsedPath.dir ? parsedPath.dir + '.' : ''}${parsedPath.name}`
+    filepath = `${parsedPath.dir ? `${parsedPath.dir}.` : ''}${parsedPath.name}`
   }
 
   filepath = filepath.replace(/\/+|\\+/g, '.')
@@ -40,13 +40,9 @@ export async function executeTests(input: AdapterInput): Promise<AdapterOutput> 
   const fullyQualifiedNames = testsToRun.map(({ testName, suiteName, filepath }) => {
     //Search the AND of the 2, since FullyQualifiedName~ is a contains
     if (!suiteName) {
-      return (
-        '(' +
-        (filepath
-          ? `FullyQualifiedName~${parseFilepathAndClassName(filepath, suiteName)} & `
-          : '') +
-        `FullyQualifiedName~.${testName})`
-      )
+      return `(${
+        filepath ? `FullyQualifiedName~${parseFilepathAndClassName(filepath, suiteName)} & ` : ''
+      }FullyQualifiedName~.${testName})`
     }
     return `(FullyQualifiedName~${parseFilepathAndClassName(filepath, suiteName)}.${testName})`
   })

--- a/packages/universal-test-adapter-maven/src/index.ts
+++ b/packages/universal-test-adapter-maven/src/index.ts
@@ -24,10 +24,10 @@ export const parseFilepathAndClassName = (
   }
 
   const parsedPath = path.parse(filepath)
-  filepath = `${parsedPath.dir ? parsedPath.dir + '/' : ''}${parsedPath.name}`
+  filepath = `${parsedPath.dir ? `${parsedPath.dir}/` : ''}${parsedPath.name}`
   if (suiteName) {
     if (parsedPath.name !== suiteName) {
-      filepath = filepath + '/' + suiteName
+      filepath = `${filepath}/${suiteName}`
     }
   }
 
@@ -43,7 +43,7 @@ export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<A
       `-Dtest=${testsToRun
         .map(({ testName, suiteName, filepath }) => {
           const parsedFilepath = parseFilepathAndClassName(filepath, suiteName)
-          return parsedFilepath + '#' + testName
+          return `${parsedFilepath}#${testName}`
         })
         .join(',')}`,
     )

--- a/packages/universal-test-adapter-pytest/src/index.ts
+++ b/packages/universal-test-adapter-pytest/src/index.ts
@@ -24,11 +24,7 @@ export async function executeTests(input: AdapterInput): Promise<AdapterOutput> 
     return matchTestsDirectly
       ? `${filepath}::${suiteName}::${testName}`
       : // Concats each filepath, suitName, testName by 'and' (ex. '(filepath and suiteName and testName)')
-        '(' +
-          (filepath ? filepath + ' and ' : '') +
-          (suiteName ? suiteName + ' and ' : '') +
-          testName +
-          ')'
+        `(${filepath ? `${filepath} and ` : ''}${suiteName ? `${suiteName} and ` : ''}${testName})`
   })
 
   if (testNamesToRun.length > 0) {


### PR DESCRIPTION
## Description

Some handy ones that we're bundled with the recommended config + running the auto-fixer

## Testing

* Confirmed that linting passes ✅

## Checklist

I have:
* 🙅‍♀️ Added new automated tests for any new functionality
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
