### PR TITLE
build: Set jest collectCoverageFrom config

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,13 @@
       "/node_modules/",
       "/dist/",
       "/tests-integ\\/test-projects/"
+    ],
+    "collectCoverageFrom": [
+      "<rootDir>/packages/**/*.ts",
+      "!**/*.test.ts",
+      "!**/tests/**",
+      "!**/dist/**",
+      "!**/node_modules/**"
     ]
   }
 }


### PR DESCRIPTION
## Description

Turns out the codecov reports are still pretty handy even though we don't have build statuses:

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/3495264/219119425-c0477daf-05fa-4e3f-b4ce-2d2b4e23c804.png">

So setting this jest config to make sure we get coverage reported from the files we actually care about covering, and nothing more.

## Testing

* Ran coverage locally and verified that only the files we care about are reported ✅

<img width="701" alt="image" src="https://user-images.githubusercontent.com/3495264/219119907-b3676aa1-4489-4285-a8ef-8ccbe0d63543.png">


## Checklist

I have:
* [ ] Added new automated tests for any new functionality
* [ ] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
