### PR TITLE
test: Add some missing unit tests

### DIFF
--- a/packages/universal-test-adapter-jest/src/buildBaseTestCommand.ts
+++ b/packages/universal-test-adapter-jest/src/buildBaseTestCommand.ts
@@ -2,19 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path'
-import { access } from 'fs/promises'
+import { access as fsAccess } from 'fs/promises'
 
 /*
  * - Use ./node_modules/.bin/jest as the executable if present
  * - Otherwise, use global jest
  */
-export async function buildBaseTestCommand(): Promise<[string, string[]]> {
+export async function buildBaseTestCommand(access = fsAccess): Promise<[string, string[]]> {
   const jestExecutablePath = path.join('.', 'node_modules', '.bin', 'jest')
-  const executable = (await exists(jestExecutablePath)) ? jestExecutablePath : 'jest'
+  const executable = (await exists(jestExecutablePath, access)) ? jestExecutablePath : 'jest'
   return [executable, []]
 }
 
-async function exists(path: string): Promise<boolean> {
+async function exists(path: string, access: typeof fsAccess): Promise<boolean> {
   try {
     await access(path)
     return true

--- a/packages/universal-test-adapter-jest/tests/buildBaseTestCommand.test.ts
+++ b/packages/universal-test-adapter-jest/tests/buildBaseTestCommand.test.ts
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { buildBaseTestCommand } from '../src/buildBaseTestCommand'
+import path from 'path'
+
+describe('buildBaseTestCommand', () => {
+  it('returns path to locally installed jest if it exists', async () => {
+    const [executable, args] = await buildBaseTestCommand(() => Promise.resolve())
+
+    expect(executable).toBe(['node_modules', '.bin', 'jest'].join(path.sep))
+    expect(args).toEqual([])
+  })
+
+  it('returns path to global jest if local jest is not installed', async () => {
+    const [executable, args] = await buildBaseTestCommand(() => Promise.reject())
+
+    expect(executable).toBe('jest')
+    expect(args).toEqual([])
+  })
+})

--- a/packages/universal-test-runner/src/readProtocol.ts
+++ b/packages/universal-test-runner/src/readProtocol.ts
@@ -56,9 +56,9 @@ function readTestsToRun(input: string | undefined): TestCase[] {
 }
 
 function readLogFileName(logFileName: string | undefined): string | undefined {
-  return logFileName
+  return logFileName || undefined
 }
 
 function readReportFormat(reportFormat: string | undefined): string | undefined {
-  return reportFormat
+  return reportFormat || undefined
 }

--- a/packages/universal-test-runner/tests/ProtocolLogger.test.ts
+++ b/packages/universal-test-runner/tests/ProtocolLogger.test.ts
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { ProtocolLogger, FsType, NowType } from '../src/ProtocolLogger'
+
+jest.mock('../src/log')
+
+describe('ProtocolLogger', () => {
+  let logger: ProtocolLogger
+  let mockNow: NowType
+  let mockFs: FsType
+
+  beforeEach(() => {
+    mockNow = (() => {
+      let count = 1
+      return () => count++
+    })()
+
+    mockFs = {
+      writeFile: jest.fn(() => Promise.resolve()),
+      mkdir: jest.fn<any, any, any>(),
+      access: jest.fn(() => Promise.resolve()),
+    }
+
+    logger = new ProtocolLogger(mockNow, mockFs)
+  })
+
+  it('writes the log file correctly', async () => {
+    logger.setLogFileName('llamas.json')
+    logger.logProtocolReadStart()
+    logger.logProtocolReadEnd()
+    logger.logDiscoveredProtocolEnvVars({ llamas: 'Larger than frogs' })
+    logger.logAdapterLoadStart()
+    logger.logAdapterPath('some/cool/adapter')
+    logger.logAdapterLoadEnd()
+    logger.logTestRunStart()
+    logger.logTestRunEnd()
+    logger.logError('some informative error message')
+
+    const result = await logger.write()
+
+    expect(mockFs.writeFile).toHaveBeenCalledWith('llamas.json', result)
+
+    expect(JSON.parse(result)).toMatchSnapshot()
+  })
+})

--- a/packages/universal-test-runner/tests/__snapshots__/ProtocolLogger.test.ts.snap
+++ b/packages/universal-test-runner/tests/__snapshots__/ProtocolLogger.test.ts.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProtocolLogger writes the log file correctly 1`] = `
+{
+  "logs": [
+    {
+      "level": "INFO",
+      "timestamp": 1,
+      "type": "PROTOCOL_READ_START",
+    },
+    {
+      "level": "INFO",
+      "timestamp": 2,
+      "type": "PROTOCOL_READ_END",
+    },
+    {
+      "data": {
+        "llamas": "Larger than frogs",
+      },
+      "level": "DEBUG",
+      "timestamp": 3,
+      "type": "DISCOVERED_PROTOCOL_ENV_VARS",
+    },
+    {
+      "data": {
+        "type": "ADAPTER_LOAD_START",
+      },
+      "level": "DEBUG",
+      "timestamp": 4,
+      "type": "CUSTOM",
+    },
+    {
+      "data": {
+        "data": "some/cool/adapter",
+        "type": "ADAPTER_PATH",
+      },
+      "level": "DEBUG",
+      "timestamp": 5,
+      "type": "CUSTOM",
+    },
+    {
+      "data": {
+        "type": "ADAPTER_LOAD_END",
+      },
+      "level": "DEBUG",
+      "timestamp": 6,
+      "type": "CUSTOM",
+    },
+    {
+      "level": "INFO",
+      "timestamp": 7,
+      "type": "TEST_RUN_START",
+    },
+    {
+      "level": "INFO",
+      "timestamp": 8,
+      "type": "TEST_RUN_END",
+    },
+    {
+      "data": "some informative error message",
+      "level": "ERROR",
+      "timestamp": 9,
+      "type": "MESSAGE",
+    },
+  ],
+}
+`;


### PR DESCRIPTION
## Description

Add some missing unit tests for ProtocolLogger class and jest's buildBaseTestCommand helper

## Testing

* Confirmed that unit and integration tests all pass ✅

## Checklist

I have:
* ✅ Added new automated tests for any new functionality
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
