### PR TITLE
refactor: Use memfs in more places instead of ad-hoc mocks

### DIFF
--- a/packages/universal-test-adapter-jest/src/buildBaseTestCommand.ts
+++ b/packages/universal-test-adapter-jest/src/buildBaseTestCommand.ts
@@ -2,21 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import path from 'path'
-import { access as fsAccess } from 'fs/promises'
+import { promises as fs } from 'fs'
 
 /*
  * - Use ./node_modules/.bin/jest as the executable if present
  * - Otherwise, use global jest
  */
-export async function buildBaseTestCommand(access = fsAccess): Promise<[string, string[]]> {
+export async function buildBaseTestCommand(): Promise<[string, string[]]> {
   const jestExecutablePath = path.join('.', 'node_modules', '.bin', 'jest')
-  const executable = (await exists(jestExecutablePath, access)) ? jestExecutablePath : 'jest'
+  const executable = (await exists(jestExecutablePath)) ? jestExecutablePath : 'jest'
   return [executable, []]
 }
 
-async function exists(path: string, access: typeof fsAccess): Promise<boolean> {
+async function exists(path: string): Promise<boolean> {
   try {
-    await access(path)
+    await fs.access(path)
     return true
   } catch (e) {
     return false

--- a/packages/universal-test-adapter-jest/tests/buildBaseTestCommand.test.ts
+++ b/packages/universal-test-adapter-jest/tests/buildBaseTestCommand.test.ts
@@ -3,17 +3,28 @@
 
 import { buildBaseTestCommand } from '../src/buildBaseTestCommand'
 import path from 'path'
+import { vol } from 'memfs'
+
+jest.mock('fs')
 
 describe('buildBaseTestCommand', () => {
+  beforeEach(() => {
+    vol.reset()
+  })
+
   it('returns path to locally installed jest if it exists', async () => {
-    const [executable, args] = await buildBaseTestCommand(() => Promise.resolve())
+    vol.fromJSON({ './node_modules/.bin/jest': 'thisisthejestexecutablelol' }, '.')
+
+    const [executable, args] = await buildBaseTestCommand()
 
     expect(executable).toBe(['node_modules', '.bin', 'jest'].join(path.sep))
     expect(args).toEqual([])
   })
 
   it('returns path to global jest if local jest is not installed', async () => {
-    const [executable, args] = await buildBaseTestCommand(() => Promise.reject())
+    vol.fromJSON({}, '.')
+
+    const [executable, args] = await buildBaseTestCommand()
 
     expect(executable).toBe('jest')
     expect(args).toEqual([])

--- a/packages/universal-test-runner/src/ProtocolLogger.ts
+++ b/packages/universal-test-runner/src/ProtocolLogger.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import fileSystem from 'fs/promises'
+import { promises as fs } from 'fs'
 import path from 'path'
 import { log } from './log'
 
@@ -26,18 +26,15 @@ interface LogEntry {
   data: any
 }
 
-export type FsType = Pick<typeof fileSystem, 'writeFile' | 'access' | 'mkdir'>
 export type NowType = () => number
 
 export class ProtocolLogger {
   private now: NowType
-  private fs: FsType
   private logs: LogEntry[]
   private logFileName?: string
 
-  constructor(now: NowType = () => Date.now(), fs: FsType = fileSystem) {
+  constructor(now: NowType = () => Date.now()) {
     this.now = now
-    this.fs = fs
     this.logs = []
     this.logFileName = undefined
   }
@@ -113,14 +110,14 @@ export class ProtocolLogger {
 
     const logFileDir = path.dirname(this.logFileName)
     try {
-      await this.fs.access(logFileDir)
+      await fs.access(logFileDir)
     } catch (e) {
-      await this.fs.mkdir(logFileDir, { recursive: true })
+      await fs.mkdir(logFileDir, { recursive: true })
     }
 
     const loggingJson = JSON.stringify({ logs: this.logs }, null, 2)
 
-    await this.fs.writeFile(this.logFileName, loggingJson)
+    await fs.writeFile(this.logFileName, loggingJson)
 
     log.info('Wrote logging information to', this.logFileName)
 


### PR DESCRIPTION
## Description

memfs is way less jank than most manual DI approaches for testing filesystem, refactoring some tests to use it in more places.

## Testing

* Confirmed that all unit tests pass ✅

## Checklist

I have:
* ✅ Added new automated tests for any new functionality
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
