### PR TITLE
fix: include index{.js,.d.ts} in published types package

### DIFF
--- a/packages/universal-test-runner-types/package.json
+++ b/packages/universal-test-runner-types/package.json
@@ -11,8 +11,7 @@
     "prepack": "npm run clean && npm run compile"
   },
   "files": [
-    "dist/lib/src",
-    "dist/types/src",
+    "dist",
     "NOTICE",
     "THIRD_PARTY_LICENSES"
   ],


### PR DESCRIPTION
## Description

Right now, only `dist/lib/src` and `dist/lib/types` are included in the packed package, meaning that actually no code is in the published package. This small changes includes all files output to the `dist/lib` directory.

## Testing

_Steps taken to verify the changes_

## Checklist

I have:
* [x] Added new automated tests for any new functionality
* [x] Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
