### PR TITLE
feat: Add runner context with support for arbitrary user flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,28 @@ The adapter is passed to the runner as follows:
 run-tests ./adapter.js
 ```
 
+Adapters can also accept a second argument called `context` of type
+[`RunnerContext`](./packages/universal-test-runner-types/src/index.ts):
+- `context.cwd`: prefer this value over using `process.cwd()` in your adapter. This allows the runner to execute the adapter in a different working directory from where the runner is executed, if needed, while still allowing the adapter to produce any artifacts (like reports) in the correct location.
+- `context.extraArgs`: Any unparsed, tokenized values passed to the runner after the end-of-argument marker `--`. Allows adapters to accommodate arbitrary flags being passed through the runner to the adapter.
+  - For example, you could pass a custom jest config to the jest adapter by running `run-tests jest -- --config ./path/to/config.js`
+
+Here's an abridged example of an adapter using context:
+
+```javascript
+const path = require('path')
+
+export function executeTests({ testNamesToRun }, { cwd, extraArgs }) {
+  // Pass unparsed args to the underlying framework, if the adapter needs to support arbitrary user flags
+  const [pass, report] = doTestExecution(extraArgs, testNamesToRun)
+
+  // prefer cwd over process.cwd() if needed
+  report.write(path.join(cwd, 'reports', 'junit.xml'))
+
+  return { exitCode: pass ? 0 : 1 }
+}
+```
+
 ### Publishing adapters to npm
 
 Structure your adapter as described above, and make sure the `main` field in

--- a/packages/universal-test-adapter-dotnet/tests/index.test.ts
+++ b/packages/universal-test-adapter-dotnet/tests/index.test.ts
@@ -1,13 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { RunnerContext } from '@aws/universal-test-runner-types'
+
 jest.mock('../src/log')
 
 describe('Dotnet adapter', () => {
   let spawn: any
+  let mockContext: RunnerContext
 
   beforeEach(() => {
     spawn = jest.fn(() => ({ status: 0 }))
+    mockContext = { cwd: '/mock/cwd', extraArgs: [] }
 
     jest.resetModules()
     jest.doMock('@aws/universal-test-runner-spawn', () => ({ spawn }))
@@ -16,16 +20,19 @@ describe('Dotnet adapter', () => {
   it('executes dotnet test when given tests of various compositions to run', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [
-        { testName: 'TestGet' },
-        {
-          filepath: 'Company/ServerlessFunctions/UnitTests/ValuesControllerTests.java',
-          testName: 'TestGet2',
-        },
-        { suiteName: 'ValuesControllerTests', testName: 'TestGet3' },
-      ],
-    })
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [
+          { testName: 'TestGet' },
+          {
+            filepath: 'Company/ServerlessFunctions/UnitTests/ValuesControllerTests.java',
+            testName: 'TestGet2',
+          },
+          { suiteName: 'ValuesControllerTests', testName: 'TestGet3' },
+        ],
+      },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('dotnet', [
@@ -40,20 +47,23 @@ describe('Dotnet adapter', () => {
   it('executes dotnet test when given tests of full compositions to run', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [
-        {
-          filepath: 'Company/ServerlessFunctions/UnitTests/',
-          suiteName: 'ValuesControllerTests',
-          testName: 'TestGet4',
-        },
-        {
-          filepath: 'Company/ServerlessFunctions/UnitTests/ValuesControllerTests',
-          suiteName: 'ValuesControllerTests',
-          testName: 'TestGet5',
-        },
-      ],
-    })
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [
+          {
+            filepath: 'Company/ServerlessFunctions/UnitTests/',
+            suiteName: 'ValuesControllerTests',
+            testName: 'TestGet4',
+          },
+          {
+            filepath: 'Company/ServerlessFunctions/UnitTests/ValuesControllerTests',
+            suiteName: 'ValuesControllerTests',
+            testName: 'TestGet5',
+          },
+        ],
+      },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('dotnet', [
@@ -67,10 +77,13 @@ describe('Dotnet adapter', () => {
   it('passes the right arguments for default report format', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [{ testName: 'TestGet' }],
-      reportFormat: 'default',
-    })
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [{ testName: 'TestGet' }],
+        reportFormat: 'default',
+      },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('dotnet', [
@@ -78,7 +91,7 @@ describe('Dotnet adapter', () => {
       '--filter',
       '(FullyQualifiedName~.TestGet)',
       '--logger',
-      `trx;LogFileName=${process.cwd()}/results.trx`,
+      `trx;LogFileName=/mock/cwd/results.trx`,
       '--logger',
       'console',
     ])

--- a/packages/universal-test-adapter-dotnet/tests/index.test.ts
+++ b/packages/universal-test-adapter-dotnet/tests/index.test.ts
@@ -96,4 +96,26 @@ describe('Dotnet adapter', () => {
       'console',
     ])
   })
+
+  it('adds extra arguments when specified', async () => {
+    mockContext.extraArgs = ['--additional-deps', './deps.json']
+
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [{ testName: 'TestGet' }],
+      },
+      mockContext,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(spawn).toHaveBeenCalledWith('dotnet', [
+      '--additional-deps',
+      './deps.json',
+      'test',
+      '--filter',
+      '(FullyQualifiedName~.TestGet)',
+    ])
+  })
 })

--- a/packages/universal-test-adapter-jest/src/index.ts
+++ b/packages/universal-test-adapter-jest/src/index.ts
@@ -5,17 +5,22 @@ import { spawn } from '@aws/universal-test-runner-spawn'
 import { log } from './log'
 import { buildBaseTestCommand } from './buildBaseTestCommand'
 
-import { AdapterInput, AdapterOutput } from '@aws/universal-test-runner-types'
+import { AdapterInput, AdapterOutput, RunnerContext } from '@aws/universal-test-runner-types'
 
 const toUnixPath = (filepath: string): string => {
   // https://quickref.me/convert-a-windows-file-path-to-unix-path
   return filepath.replace(/[\\/]+/g, '/').replace(/^([a-zA-Z]+:|\.\/)/, '')
 }
 
-export async function executeTests(adapterInput: AdapterInput): Promise<AdapterOutput> {
+export async function executeTests(
+  adapterInput: AdapterInput,
+  context: RunnerContext,
+): Promise<AdapterOutput> {
   const { testsToRun = [], reportFormat } = adapterInput
 
   const [executable, args] = await buildBaseTestCommand()
+
+  args.push(...context.extraArgs)
 
   const filepaths: string[] = []
   const describeIts: string[] = []

--- a/packages/universal-test-adapter-jest/tests/index.test.ts
+++ b/packages/universal-test-adapter-jest/tests/index.test.ts
@@ -94,4 +94,25 @@ describe('Jest adapter', () => {
       'default',
     ])
   })
+
+  it('adds extra arguments when specified', async () => {
+    mockContext.extraArgs = ['--config', './some/custom/config.js']
+
+    const { executeTests } = await import('../src/index')
+
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [{ testName: 'one' }, { testName: 'two' }, { testName: 'three' }],
+      },
+      mockContext,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(spawn).toHaveBeenCalledWith('jest', [
+      '--config',
+      './some/custom/config.js',
+      '--testNamePattern',
+      '(one)|(two)|(three)',
+    ])
+  })
 })

--- a/packages/universal-test-adapter-jest/tests/index.test.ts
+++ b/packages/universal-test-adapter-jest/tests/index.test.ts
@@ -1,13 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { RunnerContext } from '@aws/universal-test-runner-types'
+
 jest.mock('../src/log')
 
 describe('Jest adapter', () => {
   let spawn: any
+  let mockContext: RunnerContext
 
   beforeEach(() => {
     spawn = jest.fn(() => ({ status: 0 }))
+    mockContext = { cwd: '/mock/cwd', extraArgs: [] }
 
     jest.resetModules()
     jest.doMock('@aws/universal-test-runner-spawn', () => ({ spawn }))
@@ -19,9 +23,10 @@ describe('Jest adapter', () => {
   it('executes jest when given tests to run', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
-    })
+    const { exitCode } = await executeTests(
+      { testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }] },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('jest', ['--testNamePattern', '(bill)|(bob)|(mary)'])
@@ -30,13 +35,16 @@ describe('Jest adapter', () => {
   it('excludes filepaths when not included in every entry', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [
-        { testName: 'bill' },
-        { filepath: 'package/fileB.ext', testName: 'bob' },
-        { suiteName: 'suiteC', testName: 'mary' },
-      ],
-    })
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [
+          { testName: 'bill' },
+          { filepath: 'package/fileB.ext', testName: 'bob' },
+          { suiteName: 'suiteC', testName: 'mary' },
+        ],
+      },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('jest', ['--testNamePattern', '(bill)|(bob)|(suiteC mary)'])
@@ -45,13 +53,16 @@ describe('Jest adapter', () => {
   it('converts filepaths to globs correctly', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [
-        { filepath: 'package/fileB.ext', testName: 'bob' },
-        { filepath: '.*/package/.*/dirC/fileC.ext', testName: 'bob', suiteName: 'w' },
-        { filepath: '\\package\\dirA\\fileD.ext', testName: 'bob' },
-      ],
-    })
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [
+          { filepath: 'package/fileB.ext', testName: 'bob' },
+          { filepath: '.*/package/.*/dirC/fileC.ext', testName: 'bob', suiteName: 'w' },
+          { filepath: '\\package\\dirA\\fileD.ext', testName: 'bob' },
+        ],
+      },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('jest', [
@@ -65,10 +76,13 @@ describe('Jest adapter', () => {
   it('adds the correct arguments for report generation', async () => {
     const { executeTests } = await import('../src/index')
 
-    const { exitCode } = await executeTests({
-      testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
-      reportFormat: 'default',
-    })
+    const { exitCode } = await executeTests(
+      {
+        testsToRun: [{ testName: 'bill' }, { testName: 'bob' }, { testName: 'mary' }],
+        reportFormat: 'default',
+      },
+      mockContext,
+    )
 
     expect(exitCode).toBe(0)
     expect(spawn).toHaveBeenCalledWith('jest', [

--- a/packages/universal-test-runner-types/src/index.ts
+++ b/packages/universal-test-runner-types/src/index.ts
@@ -16,8 +16,11 @@ export interface AdapterOutput {
   exitCode?: number | null
 }
 
+type ExecuteTestsReturnValue = Promise<AdapterOutput> | AdapterOutput
+
 export interface Adapter {
-  executeTests(options: AdapterInput): Promise<AdapterOutput> | AdapterOutput
+  executeTests(options: AdapterInput): ExecuteTestsReturnValue
+  executeTests(options: AdapterInput, context: RunnerContext): ExecuteTestsReturnValue
 }
 
 export interface ProtocolResult {
@@ -26,4 +29,9 @@ export interface ProtocolResult {
   logFileName?: string
   reportFormat?: string
   testsToRunFile?: string
+}
+
+export interface RunnerContext {
+  extraArgs: string[]
+  cwd: string
 }

--- a/packages/universal-test-runner/src/run.ts
+++ b/packages/universal-test-runner/src/run.ts
@@ -10,6 +10,7 @@ import {
   AdapterOutput,
   TestCase,
   ProtocolResult,
+  RunnerContext,
 } from '@aws/universal-test-runner-types'
 import { ErrorCodes } from '../bin/ErrorCodes'
 
@@ -56,11 +57,12 @@ async function mapProtocolResultToAdapterInput(
 export async function run(
   adapter: Adapter,
   protocolResult: ProtocolResult,
+  context: RunnerContext = { extraArgs: [], cwd: process.cwd() },
 ): Promise<AdapterOutput> {
   const adapterInput = await mapProtocolResultToAdapterInput(protocolResult)
   try {
     log.info('Calling executeTests on adapter...')
-    const adapterOutput = await adapter.executeTests(adapterInput)
+    const adapterOutput = await adapter.executeTests(adapterInput, context)
     log.info('Finished executing tests.')
     if (adapterOutput.exitCode !== 0) {
       log.error(`Test run failed with exit code ${adapterOutput.exitCode}`)

--- a/packages/universal-test-runner/tests/run.test.ts
+++ b/packages/universal-test-runner/tests/run.test.ts
@@ -193,4 +193,29 @@ describe('Run function', () => {
       EMPTY_CONTEXT,
     )
   })
+
+  it('passes context to the adapter', async () => {
+    const mockAdapter = { executeTests: jest.fn(() => ({ exitCode: 0 })) }
+
+    const mockContext = {
+      cwd: '/some/mock/cwd',
+      extraArgs: ['--some', '--extra', '--args'],
+    }
+
+    await run(
+      mockAdapter,
+      {
+        version: '0.1.0',
+        testsToRun: 'one|two|three',
+      },
+      mockContext,
+    )
+
+    expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+      {
+        testsToRun: [{ testName: 'one' }, { testName: 'two' }, { testName: 'three' }],
+      },
+      mockContext,
+    )
+  })
 })

--- a/packages/universal-test-runner/tests/run.test.ts
+++ b/packages/universal-test-runner/tests/run.test.ts
@@ -9,6 +9,8 @@ import { vol } from 'memfs'
 jest.mock('../src/log')
 jest.mock('fs')
 
+const EMPTY_CONTEXT = { cwd: process.cwd(), extraArgs: [] }
+
 describe('Run function', () => {
   beforeEach(() => {
     vol.reset()
@@ -44,21 +46,25 @@ describe('Run function', () => {
     it('reads a list of test names', async () => {
       await run(mockAdapter, { version: '0.1.0', testsToRun: 'test1|test4|test9' })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-        testsToRun: [{ testName: 'test1' }, { testName: 'test4' }, { testName: 'test9' }],
-      })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+        { testsToRun: [{ testName: 'test1' }, { testName: 'test4' }, { testName: 'test9' }] },
+        EMPTY_CONTEXT,
+      )
     })
 
     it('reads the test suite for a single test', async () => {
       await run(mockAdapter, { version: '0.1.0', testsToRun: 'test1|test4|suitename#test9' })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-        testsToRun: [
-          { testName: 'test1' },
-          { testName: 'test4' },
-          { testName: 'test9', suiteName: 'suitename' },
-        ],
-      })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+        {
+          testsToRun: [
+            { testName: 'test1' },
+            { testName: 'test4' },
+            { testName: 'test9', suiteName: 'suitename' },
+          ],
+        },
+        EMPTY_CONTEXT,
+      )
     })
 
     it('reads the test suite for a many tests', async () => {
@@ -67,13 +73,16 @@ describe('Run function', () => {
         testsToRun: 'suite1#test1|suite2#test4|suitename#test9',
       })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-        testsToRun: [
-          { testName: 'test1', suiteName: 'suite1' },
-          { testName: 'test4', suiteName: 'suite2' },
-          { testName: 'test9', suiteName: 'suitename' },
-        ],
-      })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+        {
+          testsToRun: [
+            { testName: 'test1', suiteName: 'suite1' },
+            { testName: 'test4', suiteName: 'suite2' },
+            { testName: 'test9', suiteName: 'suitename' },
+          ],
+        },
+        EMPTY_CONTEXT,
+      )
     })
 
     it('reads the filepath only for many tests', async () => {
@@ -82,43 +91,52 @@ describe('Run function', () => {
         testsToRun: 'file1.js##test1|file2.js##test4|file3.js##test9',
       })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-        testsToRun: [
-          { testName: 'test1', filepath: 'file1.js' },
-          { testName: 'test4', filepath: 'file2.js' },
-          { testName: 'test9', filepath: 'file3.js' },
-        ],
-      })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+        {
+          testsToRun: [
+            { testName: 'test1', filepath: 'file1.js' },
+            { testName: 'test4', filepath: 'file2.js' },
+            { testName: 'test9', filepath: 'file3.js' },
+          ],
+        },
+        EMPTY_CONTEXT,
+      )
     })
 
     it('reads the filepath only for one test', async () => {
       await run(mockAdapter, { version: '0.1.0', testsToRun: 'test1|test4|file3.js##test9' })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-        testsToRun: [
-          { testName: 'test1' },
-          { testName: 'test4' },
-          { testName: 'test9', filepath: 'file3.js' },
-        ],
-      })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+        {
+          testsToRun: [
+            { testName: 'test1' },
+            { testName: 'test4' },
+            { testName: 'test9', filepath: 'file3.js' },
+          ],
+        },
+        EMPTY_CONTEXT,
+      )
     })
 
     it('reads the filepath and suite name for one test', async () => {
       await run(mockAdapter, { version: '0.1.0', testsToRun: 'test1|test4|file3.js#suite1#test9' })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-        testsToRun: [
-          { testName: 'test1' },
-          { testName: 'test4' },
-          { testName: 'test9', suiteName: 'suite1', filepath: 'file3.js' },
-        ],
-      })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+        {
+          testsToRun: [
+            { testName: 'test1' },
+            { testName: 'test4' },
+            { testName: 'test9', suiteName: 'suite1', filepath: 'file3.js' },
+          ],
+        },
+        EMPTY_CONTEXT,
+      )
     })
 
     it('reads an empty list when value is not present', async () => {
       await run(mockAdapter, { version: '0.1.0' })
 
-      expect(mockAdapter.executeTests).toHaveBeenCalledWith({ testsToRun: [] })
+      expect(mockAdapter.executeTests).toHaveBeenCalledWith({ testsToRun: [] }, EMPTY_CONTEXT)
     })
   })
 
@@ -134,9 +152,12 @@ describe('Run function', () => {
 
     await run(mockAdapter, { version: '0.1.0', testsToRunFile: '/tmp/verycoolfile' })
 
-    expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-      testsToRun: [{ testName: 'test1' }, { testName: 'test4' }, { testName: 'test9' }],
-    })
+    expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+      {
+        testsToRun: [{ testName: 'test1' }, { testName: 'test4' }, { testName: 'test9' }],
+      },
+      EMPTY_CONTEXT,
+    )
   })
 
   it('throws an error if test cases cannot be read from a file', async () => {
@@ -165,8 +186,11 @@ describe('Run function', () => {
       testsToRun: 'wont|be|executed',
     })
 
-    expect(mockAdapter.executeTests).toHaveBeenCalledWith({
-      testsToRun: [{ testName: 'test1' }, { testName: 'test4' }, { testName: 'test9' }],
-    })
+    expect(mockAdapter.executeTests).toHaveBeenCalledWith(
+      {
+        testsToRun: [{ testName: 'test1' }, { testName: 'test4' }, { testName: 'test9' }],
+      },
+      EMPTY_CONTEXT,
+    )
   })
 })


### PR DESCRIPTION
## Description

See #192 and #222. Users can now pass arbitrary flags similar to how npm scripts work. (e.g. `npm test -- --some-flag --other-flag`). Has built-in support from yargs which is handy:
```
run-tests jest -- --config ./customconfig.js
```
Will end up executing
```
jest --config ./customconfig.js
```
where previously there was no way to pass custom args down to the underlying frameworks. Should generally be used as an escape hatch as opposed to a go-to option. Currently adapters can "opt-in" to supporting this behaviour since they have to handle the extra args explicitly.

## Testing

* Confirmed that jest adapter correctly passes extra args through to jest executable ✅ 

## Checklist

I have:
* ✅ Added new automated tests for any new functionality -- **STILL NEED TO ADD TESTS**
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
