### PR TITLE
feat: Add log level command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,30 @@ Adapters can also accept a second argument called `context` of type
 - `context.cwd`: prefer this value over using `process.cwd()` in your adapter. This allows the runner to execute the adapter in a different working directory from where the runner is executed, if needed, while still allowing the adapter to produce any artifacts (like reports) in the correct location.
 - `context.extraArgs`: Any unparsed, tokenized values passed to the runner after the end-of-argument marker `--`. Allows adapters to accommodate arbitrary flags being passed through the runner to the adapter.
   - For example, you could pass a custom jest config to the jest adapter by running `run-tests jest -- --config ./path/to/config.js`
+- `context.logLevel`: The log level passed by the user to the runner when invoked from the command line, of type [`LogLevel`](./packages/universal-test-runner-types/src/index.ts). If adapters log anything when being executed, they should set the log level of their logger according to this value, where level rank from highest to lowest is `error`, `warn`, `info`, `debug`. Logs should only be written if their level rank is at least the rank of the specified log level, e.g. if the log level is `warn`, only logs of rank `error` and `warn` should be written.
 
 Here's an abridged example of an adapter using context:
 
 ```javascript
 const path = require('path')
 
-export function executeTests({ testNamesToRun }, { cwd, extraArgs }) {
+export function executeTests({ testNamesToRun }, { cwd, extraArgs, logLevel }) {
+  // Use the log level specified by the runner
+  logger.setLogLevel(context.logLevel)
+
+  logger.info('Running tests...')
+
   // Pass unparsed args to the underlying framework, if the adapter needs to support arbitrary user flags
   const [pass, report] = doTestExecution(extraArgs, testNamesToRun)
 
-  // prefer cwd over process.cwd() if needed
+  logger.info('Running writing report...')
+
+  // If cwd is needed, prefer context.cwd over process.cwd()
   report.write(path.join(cwd, 'reports', 'junit.xml'))
+
+  if (!pass) {
+    logger.error('Tests failed!')
+  }
 
   return { exitCode: pass ? 0 : 1 }
 }

--- a/packages/universal-test-adapter-dotnet/src/index.ts
+++ b/packages/universal-test-adapter-dotnet/src/index.ts
@@ -35,6 +35,8 @@ export async function executeTests(
   input: AdapterInput,
   context: RunnerContext,
 ): Promise<AdapterOutput> {
+  log.setLogLevel(context.logLevel)
+
   const { testsToRun = [], reportFormat } = input
 
   const executable = 'dotnet'

--- a/packages/universal-test-adapter-dotnet/tests/index.test.ts
+++ b/packages/universal-test-adapter-dotnet/tests/index.test.ts
@@ -11,7 +11,7 @@ describe('Dotnet adapter', () => {
 
   beforeEach(() => {
     spawn = jest.fn(() => ({ status: 0 }))
-    mockContext = { cwd: '/mock/cwd', extraArgs: [] }
+    mockContext = { cwd: '/mock/cwd', extraArgs: [], logLevel: 'info' }
 
     jest.resetModules()
     jest.doMock('@aws/universal-test-runner-spawn', () => ({ spawn }))

--- a/packages/universal-test-adapter-gradle/src/index.ts
+++ b/packages/universal-test-adapter-gradle/src/index.ts
@@ -4,7 +4,7 @@
 import { spawn } from '@aws/universal-test-runner-spawn'
 import { log } from './log'
 
-import { AdapterInput, AdapterOutput } from '@aws/universal-test-runner-types'
+import { AdapterInput, AdapterOutput, RunnerContext } from '@aws/universal-test-runner-types'
 
 // not safe for windows, need to handle backslashes
 // Transforms filepath input from 'folderA/folderB/file.java' to 'folderA.folderB'
@@ -13,7 +13,12 @@ export const parsePackagePath = (filepath: string): string => {
   return newFilepath.substring(0, filepath.lastIndexOf('/')).replace(/\//g, '.')
 }
 
-export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+export async function executeTests(
+  { testsToRun = [] }: AdapterInput,
+  context?: RunnerContext,
+): Promise<AdapterOutput> {
+  context && log.setLogLevel(context.logLevel)
+
   const executable = 'gradle'
   const args = ['test']
   const testNamesToRun = testsToRun.map(({ testName, suiteName, filepath }) => {

--- a/packages/universal-test-adapter-jest/src/index.ts
+++ b/packages/universal-test-adapter-jest/src/index.ts
@@ -16,6 +16,8 @@ export async function executeTests(
   adapterInput: AdapterInput,
   context: RunnerContext,
 ): Promise<AdapterOutput> {
+  log.setLogLevel(context.logLevel)
+
   const { testsToRun = [], reportFormat } = adapterInput
 
   const [executable, args] = await buildBaseTestCommand()

--- a/packages/universal-test-adapter-jest/tests/index.test.ts
+++ b/packages/universal-test-adapter-jest/tests/index.test.ts
@@ -11,7 +11,7 @@ describe('Jest adapter', () => {
 
   beforeEach(() => {
     spawn = jest.fn(() => ({ status: 0 }))
-    mockContext = { cwd: '/mock/cwd', extraArgs: [] }
+    mockContext = { cwd: '/mock/cwd', extraArgs: [], logLevel: 'info' }
 
     jest.resetModules()
     jest.doMock('@aws/universal-test-runner-spawn', () => ({ spawn }))

--- a/packages/universal-test-adapter-maven/src/index.ts
+++ b/packages/universal-test-adapter-maven/src/index.ts
@@ -4,7 +4,7 @@
 import { spawn } from '@aws/universal-test-runner-spawn'
 import { log } from './log'
 
-import { AdapterInput, AdapterOutput } from '@aws/universal-test-runner-types'
+import { AdapterInput, AdapterOutput, RunnerContext } from '@aws/universal-test-runner-types'
 
 import path from 'path'
 
@@ -34,7 +34,12 @@ export const parseFilepathAndClassName = (
   return toUnixPath(filepath)
 }
 
-export async function executeTests({ testsToRun = [] }: AdapterInput): Promise<AdapterOutput> {
+export async function executeTests(
+  { testsToRun = [] }: AdapterInput,
+  context?: RunnerContext,
+): Promise<AdapterOutput> {
+  context && log.setLogLevel(context.logLevel)
+
   const executable = 'mvn'
   const args = []
 

--- a/packages/universal-test-adapter-pytest/src/index.ts
+++ b/packages/universal-test-adapter-pytest/src/index.ts
@@ -4,9 +4,14 @@
 import { spawn } from '@aws/universal-test-runner-spawn'
 import { log } from './log'
 
-import { AdapterInput, AdapterOutput } from '@aws/universal-test-runner-types'
+import { AdapterInput, AdapterOutput, RunnerContext } from '@aws/universal-test-runner-types'
 
-export async function executeTests(input: AdapterInput): Promise<AdapterOutput> {
+export async function executeTests(
+  input: AdapterInput,
+  context?: RunnerContext,
+): Promise<AdapterOutput> {
+  context && log.setLogLevel(context.logLevel)
+
   const { testsToRun = [], reportFormat } = input
 
   const executable = 'pytest'

--- a/packages/universal-test-runner-logger/package.json
+++ b/packages/universal-test-runner-logger/package.json
@@ -18,6 +18,9 @@
   "dependencies": {
     "chalk": "^4.1.2"
   },
+  "devDependencies": {
+    "@aws/universal-test-runner-types": "*"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/aws/universal-test-runner"

--- a/packages/universal-test-runner-logger/src/index.ts
+++ b/packages/universal-test-runner-logger/src/index.ts
@@ -3,13 +3,30 @@
 
 import chalk from 'chalk'
 
+import { LogLevel } from '@aws/universal-test-runner-types'
+
 type LogHandler = (...args: any[]) => void
 
-export interface Logger {
-  info: LogHandler
-  error: LogHandler
+export interface LoggingMethods {
   debug: LogHandler
+  info: LogHandler
   warn: LogHandler
+  error: LogHandler
+}
+
+const LogLevelRanks: { [key in LogLevel]: number } = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+} as const
+
+export function shouldLog(methodName: keyof LoggingMethods, logLevel: LogLevel): boolean {
+  return LogLevelRanks[methodName] >= LogLevelRanks[logLevel]
+}
+
+export interface Logger extends LoggingMethods {
+  setLogLevel: (level: LogLevel) => void
 }
 
 function prefix(fn: LogHandler, prefixString: string): LogHandler {
@@ -19,7 +36,7 @@ function prefix(fn: LogHandler, prefixString: string): LogHandler {
 }
 
 /* eslint-disable no-console */
-const defaultMethods: Logger = {
+const defaultMethods: LoggingMethods = {
   info: (...args) => console.error(chalk.blueBright('[INFO]'), ...args),
   error: (...args) => console.error(chalk.redBright('[ERROR]'), ...args),
   warn: (...args) => console.error(chalk.yellowBright('[WARN]'), ...args),
@@ -29,16 +46,27 @@ const defaultMethods: Logger = {
 
 export function makeLogger(
   prefixString: string,
-  overrides: Partial<Logger> = defaultMethods,
+  overrides: Partial<LoggingMethods> = defaultMethods,
 ): Logger {
   const methods = {
     ...defaultMethods,
     ...overrides,
   }
+
+  let logLevel: LogLevel = 'info'
+
   return {
-    info: prefix(methods.info, prefixString),
-    error: prefix(methods.error, prefixString),
-    warn: prefix(methods.warn, prefixString),
-    debug: prefix(methods.debug, prefixString),
+    setLogLevel: (_logLevel) => {
+      logLevel = _logLevel
+    },
+    ...(['debug', 'info', 'warn', 'error'] as const).reduce(
+      (loggingMethods, methodName) => ({
+        ...loggingMethods,
+        [methodName]: (...args: any[]) => {
+          shouldLog(methodName, logLevel) && prefix(methods[methodName], prefixString)(...args)
+        },
+      }),
+      {} as LoggingMethods,
+    ),
   }
 }

--- a/packages/universal-test-runner-logger/tests/log.test.ts
+++ b/packages/universal-test-runner-logger/tests/log.test.ts
@@ -1,16 +1,41 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { makeLogger, Logger } from '../src/index'
+import { LogLevel } from '@aws/universal-test-runner-types'
+
+import { makeLogger, LoggingMethods, shouldLog } from '../src/index'
 
 describe('Logger', () => {
-  it.each(['error', 'info', 'debug', 'warn'] as (keyof Logger)[])(
+  it.each(['error', 'info', 'debug', 'warn'] as (keyof LoggingMethods)[])(
     'adds the log prefix to the %s method',
     (methodName) => {
       const method = jest.fn()
       const logger = makeLogger('my-cool-prefix:', { [methodName]: method })
+      logger.setLogLevel('debug')
+
       logger[methodName]('what', 'is', 'up')
+
       expect(method).toHaveBeenCalledWith('my-cool-prefix:', 'what', 'is', 'up')
+    },
+  )
+
+  describe.each(['debug', 'info', 'warn', 'error'] as LogLevel[])(
+    'with log level %s',
+    (logLevel) => {
+      it.each(['debug', 'info', 'warn', 'error'] as (keyof LoggingMethods)[])(
+        'calls the %s method if needed',
+        (methodName) => {
+          const method = jest.fn()
+          const logger = makeLogger('', { [methodName]: method })
+          logger.setLogLevel(logLevel)
+
+          logger[methodName]()
+
+          const called = method.mock.calls.length > 0
+
+          expect(called).toEqual(shouldLog(methodName, logLevel))
+        },
+      )
     },
   )
 })

--- a/packages/universal-test-runner-types/src/index.ts
+++ b/packages/universal-test-runner-types/src/index.ts
@@ -31,7 +31,10 @@ export interface ProtocolResult {
   testsToRunFile?: string
 }
 
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
 export interface RunnerContext {
   extraArgs: string[]
   cwd: string
+  logLevel: LogLevel
 }

--- a/packages/universal-test-runner/bin/cli.ts
+++ b/packages/universal-test-runner/bin/cli.ts
@@ -16,7 +16,7 @@ import { loadAdapter as _loadAdapter, builtInAdapters } from '../src/loadAdapter
 import { log } from '../src/log'
 import { ProtocolLogger } from '../src/ProtocolLogger'
 import { ErrorCodes, UniversalTestRunnerError } from './ErrorCodes'
-import { Adapter, ProtocolResult, RunnerContext } from '@aws/universal-test-runner-types'
+import { Adapter, ProtocolResult, RunnerContext, LogLevel } from '@aws/universal-test-runner-types'
 
 const argv = yargs(hideBin(process.argv))
   .parserConfiguration({
@@ -44,6 +44,13 @@ const argv = yargs(hideBin(process.argv))
           type: 'string',
         })
         .example('$0 ./my-adapter.js', 'Run tests with a custom adapter')
+        .option('log-level', {
+          alias: 'l',
+          choices: ['debug', 'info', 'warn', 'error'] as LogLevel[],
+          type: 'string',
+          default: 'info',
+          describe: 'Set the log level',
+        })
         .example(
           '$0 jest -- --config ./custom-jest-config.js',
           'Pass custom arguments and flags directly to an adapter',
@@ -59,6 +66,8 @@ const argv = yargs(hideBin(process.argv))
   .wrap(null)
   .parseSync()
 
+log.setLogLevel(argv.logLevel as LogLevel)
+
 const protocolLogger = new ProtocolLogger()
 
 void (async () => {
@@ -69,6 +78,7 @@ void (async () => {
     const exitCode = await runTests(adapter, protocolResult, {
       cwd: process.cwd(),
       extraArgs: ((argv['--'] as any[]) ?? []).map((arg: any) => String(arg)),
+      logLevel: argv.logLevel as LogLevel,
     })
     await cleanUp()
     process.exit(exitCode)

--- a/packages/universal-test-runner/src/run.ts
+++ b/packages/universal-test-runner/src/run.ts
@@ -57,7 +57,7 @@ async function mapProtocolResultToAdapterInput(
 export async function run(
   adapter: Adapter,
   protocolResult: ProtocolResult,
-  context: RunnerContext = { extraArgs: [], cwd: process.cwd() },
+  context: RunnerContext = { extraArgs: [], cwd: process.cwd(), logLevel: 'info' },
 ): Promise<AdapterOutput> {
   const adapterInput = await mapProtocolResultToAdapterInput(protocolResult)
   try {

--- a/packages/universal-test-runner/tests/run.test.ts
+++ b/packages/universal-test-runner/tests/run.test.ts
@@ -3,13 +3,13 @@
 
 import { run } from '../src/run'
 import { ErrorCodes } from '../bin/ErrorCodes'
-import { Adapter } from '@aws/universal-test-runner-types'
+import { Adapter, RunnerContext } from '@aws/universal-test-runner-types'
 import { vol } from 'memfs'
 
 jest.mock('../src/log')
 jest.mock('fs')
 
-const EMPTY_CONTEXT = { cwd: process.cwd(), extraArgs: [] }
+const EMPTY_CONTEXT: RunnerContext = { cwd: process.cwd(), extraArgs: [], logLevel: 'info' }
 
 describe('Run function', () => {
   beforeEach(() => {
@@ -197,9 +197,10 @@ describe('Run function', () => {
   it('passes context to the adapter', async () => {
     const mockAdapter = { executeTests: jest.fn(() => ({ exitCode: 0 })) }
 
-    const mockContext = {
+    const mockContext: RunnerContext = {
       cwd: '/some/mock/cwd',
       extraArgs: ['--some', '--extra', '--args'],
+      logLevel: 'info',
     }
 
     await run(


### PR DESCRIPTION
## Description

Allows users to specify a `--log-level` option when executing an adapter.

## Testing

* Verified that CLI fails for invalid log level values ✅ 
* Verified that log level is adhered to ✅:

```
∫ msrose ~/workplace/quokka/universal-test-runner git:(main) ✗ ∫
Σ node ./node_modules/.bin/run-tests pytest --log-level error
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.9.16, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Volumes/workplace/quokka/universal-test-runner
collected 3 items

tests-integ/test-projects/pytest/test_example.py ...                                                                                                                                                                                                                     [100%]

============================================================================================================================== 3 passed in 0.14s ===============================================================================================================================
∫ msrose ~/workplace/quokka/universal-test-runner git:(main) ✗ ∫
Σ node ./node_modules/.bin/run-tests pytest --log-level warn
[WARN] [universal-test-runner]: Protocol version not specified! Defaulting to 0.1.0
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.9.16, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Volumes/workplace/quokka/universal-test-runner
collected 3 items

tests-integ/test-projects/pytest/test_example.py ...                                                                                                                                                                                                                     [100%]

============================================================================================================================== 3 passed in 0.13s ===============================================================================================================================
∫ msrose ~/workplace/quokka/universal-test-runner git:(main) ✗ ∫
Σ node ./node_modules/.bin/run-tests pytest --log-level info
[WARN] [universal-test-runner]: Protocol version not specified! Defaulting to 0.1.0
[INFO] [universal-test-runner]: Using Test Execution Protocol version 0.1.0
[INFO] [universal-test-runner]: Loaded adapter from @aws/universal-test-adapter-pytest
[INFO] [universal-test-runner]: Calling executeTests on adapter...
[INFO] [universal-test-adapter-pytest]: Running tests with pytest using command: pytest
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.9.16, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Volumes/workplace/quokka/universal-test-runner
collected 3 items

tests-integ/test-projects/pytest/test_example.py ...                                                                                                                                                                                                                     [100%]

============================================================================================================================== 3 passed in 0.13s ===============================================================================================================================
[INFO] [universal-test-runner]: Finished executing tests.
∫ msrose ~/workplace/quokka/universal-test-runner git:(main) ✗ ∫
Σ node ./node_modules/.bin/run-tests pytest --log-level debug
[WARN] [universal-test-runner]: Protocol version not specified! Defaulting to 0.1.0
[INFO] [universal-test-runner]: Using Test Execution Protocol version 0.1.0
[INFO] [universal-test-runner]: Loaded adapter from @aws/universal-test-adapter-pytest
[INFO] [universal-test-runner]: Calling executeTests on adapter...
[INFO] [universal-test-adapter-pytest]: Running tests with pytest using command: pytest
============================================================================================================================= test session starts ==============================================================================================================================
platform darwin -- Python 3.9.16, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /Volumes/workplace/quokka/universal-test-runner
collected 3 items

tests-integ/test-projects/pytest/test_example.py ...                                                                                                                                                                                                                     [100%]

============================================================================================================================== 3 passed in 0.13s ===============================================================================================================================
[INFO] [universal-test-runner]: Finished executing tests.
```

## Checklist

I have:
* ✅ Added new automated tests for any new functionality
* ✅ Run `npm run build`

## Licensing statement (do not modify)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
